### PR TITLE
chore(build.gradle.kts): update fixers URL to point to the correct re…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,7 +53,7 @@ fixers {
 		id = "ssm"
 		name = "Ssm Data"
 		description = "Aggregate all ssm data source to optimize request"
-		url = "https://github.com/komune-io/fixers-ssm"
+		url = "https://github.com/komune-io/fixers-c2"
 	}
 
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
 sonar.organization=komune-io
-sonar.projectKey=komune-io_fixers-ssm
+sonar.projectKey=komune-io_fixers-c2
 
 # relative paths to source directories. More details and properties are described
 # in https://sonarcloud.io/documentation/project-administration/narrowing-the-focus/


### PR DESCRIPTION
…pository

chore(sonar-project.properties): update sonar.projectKey to reflect the correct project key The fixers URL in the build.gradle.kts file has been updated to point to the correct repository, "https://github.com/komune-io/fixers-c2". This change ensures that the URL is accurate and up-to-date. Additionally, the sonar.projectKey in the sonar-project.properties file has been updated to "komune-io_fixers-c2" to reflect the correct project key for SonarCloud analysis. This change ensures that the correct project is being analyzed by SonarCloud.