### PR TITLE
Add promote task 

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -11,8 +11,10 @@ jobs:
     secrets:
       GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
       GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
-      PKG_MAVEN_USERNAME: ${{ secrets.PKG_MAVEN_USERNAME }}
-      PKG_MAVEN_TOKEN: ${{ secrets.PKG_MAVEN_TOKEN }}
+      PKG_GITHUB_USERNAME: ${{ secrets.PKG_GITHUB_USERNAME }}
+      PKG_GITHUB_TOKEN: ${{ secrets.PKG_GITHUB_TOKEN }}
+      PKG_SONATYPE_OSS_USERNAME: ${{ secrets.PKG_SONATYPE_OSS_USERNAME }}
+      PKG_SONATYPE_OSS_TOKEN: ${{ secrets.PKG_SONATYPE_OSS_TOKEN }}
 
   docs:
     uses: komune-io/fixers-gradle/.github/workflows/publish-storybook-workflow.yml@main

--- a/.github/workflows/sec.yml
+++ b/.github/workflows/sec.yml
@@ -7,8 +7,8 @@ jobs:
     uses: komune-io/fixers-gradle/.github/workflows/sec-workflow.yml@main
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      PKG_MAVEN_USERNAME: ${{ secrets.PKG_MAVEN_USERNAME }}
-      PKG_MAVEN_TOKEN: ${{ secrets.PKG_MAVEN_TOKEN }}
+      PKG_GITHUB_USERNAME: ${{ secrets.PKG_GITHUB_USERNAME }}
+      PKG_GITHUB_TOKEN: ${{ secrets.PKG_GITHUB_TOKEN }}
     permissions:
       contents: write
       pull-requests: read

--- a/Makefile
+++ b/Makefile
@@ -20,13 +20,13 @@ promote: promote-libs
 
 # Old task
 libs: package-kotlin
-package-kotlin: lint-libs build-libs test-libs package-libs
+package-kotlin: lint-libs build-libs test-libs publish-libs
 
 lint-libs:
 	./gradlew detekt
 
 build-libs:
-	VERSION=$(VERSION) ./gradlew clean build publishToMavenLocal -x test
+	VERSION=$(VERSION) ./gradlew clean build publishToMavenLocal --refresh-dependencies -x test
 
 test-libs:
 	./gradlew test
@@ -45,7 +45,7 @@ chaincode-api-gateway-package: docker-chaincode-api-gateway-build docker-chainco
 
 
 docker-chaincode-api-gateway-build:
-	VERSION=${VERSION} ./gradlew build publishToMavenLocal ${CHAINCODE_APP_PACKAGE} -x test --stacktrace
+	VERSION=${VERSION} ./gradlew build publishToMavenLocal ${CHAINCODE_APP_PACKAGE} --refresh-dependencies -x test
 
 docker-chaincode-api-gateway-push:
 	@docker push ${CHAINCODE_APP_IMG}

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ test-pre:
 	@make dev up
 	@make dev c2-sandbox-ssm logs
 	@make dev up
+	sudo echo "127.0.0.1 ca.bc-coop.bclan" | sudo tee -a /etc/hosts
+	sudo echo "127.0.0.1 peer0.bc-coop.bclan" | sudo tee -a /etc/hosts
+	sudo echo "127.0.0.1 orderer.bclan" | sudo tee -a /etc/hosts
 test: test-libs
 test-post:
 	@make dev down

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ chaincode-api-gateway-package: docker-chaincode-api-gateway-build docker-chainco
 
 
 docker-chaincode-api-gateway-build:
-	VERSION=${VERSION} ./gradlew build publishToMavenLocal ${CHAINCODE_APP_PACKAGE} --refresh-dependencies -x test
+	VERSION=$(VERSION) ./gradlew build publishToMavenLocal ${CHAINCODE_APP_PACKAGE} --refresh-dependencies -x test
 
 docker-chaincode-api-gateway-push:
 	@docker push ${CHAINCODE_APP_IMG}

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,6 @@ CHAINCODE_APP_NAME	   	 	:= ghcr.io/komune-io/chaincode-api-gateway
 CHAINCODE_APP_IMG	    	:= ${CHAINCODE_APP_NAME}:${VERSION}
 CHAINCODE_APP_PACKAGE	   	:= :c2-chaincode:chaincode-api:chaincode-api-gateway:bootBuildImage
 
-.PHONY: version
-
 lint: lint-libs
 build: build-libs
 test-pre:
@@ -16,7 +14,9 @@ test-pre:
 test: test-libs
 test-post:
 	@make dev down
-package: package-libs
+
+publish: publish-libs
+promote: promote-libs
 
 # Old task
 libs: package-kotlin
@@ -26,16 +26,20 @@ lint-libs:
 	./gradlew detekt
 
 build-libs:
-	./gradlew build publishToMavenLocal -x test
+	VERSION=$(VERSION) ./gradlew clean build publishToMavenLocal -x test
 
 test-libs:
 	./gradlew test
 
-package-libs: build-libs
-	./gradlew publish
+publish-libs:
+	VERSION=$(VERSION) PKG_MAVEN_REPO=github ./gradlew publish --info
 
+promote-libs:
+	VERSION=$(VERSION) PKG_MAVEN_REPO=sonatype_oss ./gradlew publish
+
+.PHONY: version
 version:
-	echo "$$VERSION"
+	@echo "$(VERSION)"
 
 chaincode-api-gateway-package: docker-chaincode-api-gateway-build docker-chaincode-api-gateway-push
 


### PR DESCRIPTION
…pe OSS

chore(sec.yml): update secrets for GitHub package registry in security workflow feat(Makefile): add new targets 'publish' and 'promote' for publishing and promoting libraries to GitHub and Sonatype OSS repositories The changes in the dev.yml and sec.yml workflows involve updating the secrets for the GitHub package registry and Sonatype OSS to ensure the correct credentials are used for authentication. In the Makefile, new targets 'publish' and 'promote' are added to facilitate publishing and promoting libraries to the GitHub and Sonatype OSS repositories respectively, providing a streamlined process for managing library releases.