### PR TITLE
fix(build.gradle.kts): change project group from "io.komune.ssm" to "io.komune.c2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 }
 
 allprojects {
-	group = "io.komune.ssm"
+	group = "io.komune.c2"
 	version = System.getenv("VERSION") ?: "experimental-SNAPSHOT"
 }
 


### PR DESCRIPTION
The project group has been updated to "io.komune.c2" to ensure consistency with the project naming conventions. This change aligns the project with the expected naming standards and improves clarity for developers working on the project.