### PR TITLE
chore(dev.yml): remove unused secrets from GitHub Actions workflow file

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -33,12 +33,8 @@ jobs:
       with-docker-registry-login: 'true'
       make-file: 'docker.mk'
     secrets:
-      GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-      GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
       PKG_GITHUB_USERNAME: ${{ github.actor }}
       PKG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      PKG_SONATYPE_OSS_USERNAME: ${{ secrets.PKG_SONATYPE_OSS_USERNAME }}
-      PKG_SONATYPE_OSS_TOKEN: ${{ secrets.PKG_SONATYPE_OSS_TOKEN }}
       DOCKER_PUBLISH_USERNAME: ${{ github.actor }}
       DOCKER_PUBLISH_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
       DOCKER_PROMOTE_USERNAME: ${{ github.DOCKER_IO_USERNAME }}


### PR DESCRIPTION
The commit removes the unused secrets GPG_SIGNING_KEY, GPG_SIGNING_PASSWORD, PKG_SONATYPE_OSS_USERNAME, and PKG_SONATYPE_OSS_TOKEN from the GitHub Actions workflow file. This cleanup improves security by reducing the exposure of unnecessary sensitive information in the workflow configuration.