### PR TITLE
ci(dev.yml): add support for triggering workflows on tags and define actions for tag events

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -7,6 +7,8 @@ on:
     branches:
       - main
       - 'release/*'
+    tags:
+      - '*'
 
 jobs:
   libs:
@@ -16,6 +18,7 @@ jobs:
       packages: write
     with:
       make-file: 'libs.mk'
+      on-tag: 'promote'
     secrets:
       GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
       GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
@@ -48,10 +51,15 @@ jobs:
       pages: write
       id-token: write
     with:
+      on-tag: 'publish_promote'
       with-chromatic: false
       storybook-dir: storybook
       storybook-static-dir: storybook-static
     secrets:
       NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+      DOCKER_PUBLISH_USERNAME: ${{ github.actor }}
+      DOCKER_PUBLISH_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      DOCKER_PROMOTE_USERNAME: ${{ secrets.DOCKER_IO_USERNAME }}
+      DOCKER_PROMOTE_PASSWORD: ${{ secrets.DOCKER_IO_PASSWORD }}
 


### PR DESCRIPTION
The workflow file now includes support for triggering workflows on tags in addition to branches. Actions are defined for tag events such as 'promote' and 'publish_promote'. This allows for more flexibility in managing the CI/CD process based on different events like tagging a release or promoting a build.