### PR TITLE
chore(libs.mk): remove unnecessary refresh-dependencies flag from build target

### DIFF
--- a/libs.mk
+++ b/libs.mk
@@ -1,10 +1,12 @@
 VERSION = $(shell cat VERSION)
 
+.PHONY: lint build test test-pre publish promote
+
 lint:
 	./gradlew detekt
 
 build:
-	VERSION=$(VERSION) ./gradlew clean build publishToMavenLocal --refresh-dependencies -x test
+	VERSION=$(VERSION) ./gradlew clean build publishToMavenLocal -x test
 
 test-pre:
 	@make dev up


### PR DESCRIPTION
The refresh-dependencies flag was removed from the build target to streamline the build process and avoid unnecessary dependency refreshes.