### PR TITLE
Invoke array of blockchain command

### DIFF
--- a/c2-chaincode/chaincode-api/chaincode-api-auth/build.gradle.kts
+++ b/c2-chaincode/chaincode-api/chaincode-api-auth/build.gradle.kts
@@ -5,14 +5,10 @@ plugins {
 }
 
 dependencies {
-    implementation ("org.jetbrains.kotlin:kotlin-reflect")
-    implementation ("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
-
     api ("org.springframework.boot:spring-boot-starter-security:${Versions.springBoot}")
     implementation ("org.springframework.security:spring-security-oauth2-resource-server:${Versions.springSecurity}")
     implementation( "org.springframework.security:spring-security-oauth2-jose:${Versions.springSecurity}")
 
     implementation ("org.springframework.boot:spring-boot-autoconfigure:${Versions.springBoot}")
 
-    implementation ("io.projectreactor:reactor-core:${Versions.reactor}")
 }

--- a/c2-chaincode/chaincode-api/chaincode-api-gateway/src/main/kotlin/io/komune/c2/chaincode/api/gateway/ChaincodeRestEndpoint.kt
+++ b/c2-chaincode/chaincode-api/chaincode-api-gateway/src/main/kotlin/io/komune/c2/chaincode/api/gateway/ChaincodeRestEndpoint.kt
@@ -5,6 +5,7 @@ import io.komune.c2.chaincode.api.gateway.chaincode.ChaincodeService
 import io.komune.c2.chaincode.api.gateway.chaincode.model.Cmd
 import io.komune.c2.chaincode.api.gateway.chaincode.model.ErrorResponse
 import io.komune.c2.chaincode.api.gateway.chaincode.model.InvokeParams
+import io.komune.c2.chaincode.api.gateway.chaincode.model.InvokeReturn
 import io.komune.c2.chaincode.api.gateway.config.ChainCodeId
 import io.komune.c2.chaincode.api.gateway.config.ChannelId
 import org.springframework.http.HttpStatus
@@ -48,6 +49,11 @@ class ChaincodeRestEndpoint(
 	fun invokeJson(
 		@RequestBody args: InvokeParams
 	): CompletableFuture<String> = chaincodeService.execute(args)
+
+	@PostMapping(path = ["invoke"], consumes = [MediaType.APPLICATION_JSON_VALUE])
+	suspend fun invokeJson(
+		@RequestBody args: List<InvokeParams>
+	): List<InvokeReturn> = chaincodeService.execute(args)
 
 	@ExceptionHandler(InvokeException::class)
 	fun handleException(invokeException: InvokeException): ResponseEntity<ErrorResponse> {

--- a/c2-chaincode/chaincode-api/chaincode-api-gateway/src/main/kotlin/io/komune/c2/chaincode/api/gateway/config/HeraclesConfigProps.kt
+++ b/c2-chaincode/chaincode-api/chaincode-api-gateway/src/main/kotlin/io/komune/c2/chaincode/api/gateway/config/HeraclesConfigProps.kt
@@ -31,9 +31,7 @@ class HeraclesConfigProps(
 	fun getChannelChaincodes(): Map<ChannelId, ChannelChaincode> {
 		val user = requireNotNull(user) { "Bad user[${user}] in application.yml" }
 		val config = requireNotNull(config) { "Bad config[${config}] in application.yml" }
-		return ChannelChaincode.fromConfig(getCcids(), user, config, getEndorsers()).also {
-			println(it)
-		}
+		return ChannelChaincode.fromConfig(getCcids(), user, config, getEndorsers())
 	}
 
 	fun getChannelChaincodePair(channelId: ChannelId?, chainCodeId: String?): ChannelChaincodePair {

--- a/c2-ssm/ssm-bdd/ssm-bdd-features/src/main/kotlin/ssm/bdd/config/SsmCommandStep.kt
+++ b/c2-ssm/ssm-bdd/ssm-bdd-features/src/main/kotlin/ssm/bdd/config/SsmCommandStep.kt
@@ -202,7 +202,7 @@ abstract class SsmCommandStep {
 
 	protected abstract suspend fun registerUser(agent: Agent)
 
-	protected suspend fun loadSignerAdmin(adminName: AgentName? = null, filename: String? = null): SignerAdmin {
+	private fun loadSignerAdmin(adminName: AgentName? = null, filename: String? = null): SignerAdmin {
 		return when {
 			adminName != null -> {
 				SignerAdmin.loadFromFile("ssm-admin", filename)
@@ -214,7 +214,6 @@ abstract class SsmCommandStep {
 				SignerAdmin.loadFromFile("ssm-admin", "local/admin/ssm-admin")
 			}
 		}
-
 	}
 
 	protected abstract suspend fun loadSigner(agentName: AgentName, filename: String): SignerUser

--- a/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/model/uri/ChaincodeUri.kt
+++ b/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/model/uri/ChaincodeUri.kt
@@ -43,6 +43,6 @@ fun ChaincodeUriDTO.toSsmUri(ssmName: SsmName): SsmUri {
 	return SsmUri.from(burst().channelId, burst().chaincodeId, ssmName)
 }
 
-fun ChaincodeUri.Companion.from(channelId: ChannelId, chaincodeId: ChaincodeId): ChaincodeUri {
+fun ChaincodeUri.Companion.from(channelId: ChannelId?, chaincodeId: ChaincodeId?): ChaincodeUri {
 	return ChaincodeUri("chaincode:$channelId:$chaincodeId")
 }

--- a/c2-ssm/ssm-couchdb/ssm-couchdb-sdk/src/main/kotlin/ssm/couchdb/client/CouchdbSsmClient.kt
+++ b/c2-ssm/ssm-couchdb/ssm-couchdb-sdk/src/main/kotlin/ssm/couchdb/client/CouchdbSsmClient.kt
@@ -140,9 +140,7 @@ class CouchdbSsmClient(
 			query.limit(limit)
 		}
 
-		return cloudant.postChanges(query.build(), ssmName, sessionName).execute().result.also {
-			println(it)
-		}
+		return cloudant.postChanges(query.build(), ssmName, sessionName).execute().result
 	}
 
 	suspend fun installSsmChangesFilter(dbName: DatabaseName) = suspendCoroutine<Boolean> { continuation ->

--- a/c2-ssm/ssm-sdk/ssm-sdk-core/src/main/kotlin/ssm/sdk/core/SsmCommandService.kt
+++ b/c2-ssm/ssm-sdk/ssm-sdk-core/src/main/kotlin/ssm/sdk/core/SsmCommandService.kt
@@ -1,0 +1,106 @@
+package ssm.sdk.core
+
+import org.slf4j.LoggerFactory
+import ssm.chaincode.dsl.model.Agent
+import ssm.chaincode.dsl.model.AgentName
+import ssm.chaincode.dsl.model.Ssm
+import ssm.chaincode.dsl.model.SsmContext
+import ssm.chaincode.dsl.model.SsmSession
+import ssm.chaincode.dsl.model.uri.ChaincodeUri
+import ssm.sdk.core.command.SsmCreateCommand
+import ssm.sdk.core.command.SsmPerformCommand
+import ssm.sdk.core.command.SsmStartCommand
+import ssm.sdk.core.command.UserRegisterCommand
+import ssm.sdk.core.invoke.command.CreateCmd
+import ssm.sdk.core.invoke.command.PerformCmd
+import ssm.sdk.core.invoke.command.RegisterCmd
+import ssm.sdk.core.invoke.command.StartCmd
+import ssm.sdk.core.ktor.SsmRequester
+import ssm.sdk.dsl.InvokeReturn
+import ssm.sdk.dsl.SsmCmd
+import ssm.sdk.dsl.SsmCmdSigned
+import ssm.sdk.sign.SsmCmdSigner
+
+class SsmCommandService(
+	private val ssmService: SsmService,
+) {
+	private val logger = LoggerFactory.getLogger(SsmCommandService::class.java)
+
+	suspend fun sendRegisterUser(
+		chaincodeUri: ChaincodeUri,
+		signerName: AgentName,
+		commands: List<UserRegisterCommand>
+	): List<InvokeReturn> {
+		return ssmService.signsAndSend(chaincodeUri, signerName) {
+			commands.map { command ->
+				logger.info("Register user[${command.agent.name}] with signer[${signerName}]")
+				registerUser(command.agent)
+			}
+		}
+	}
+
+	suspend fun sendCreate(
+		chaincodeUri: ChaincodeUri,
+		signerName: AgentName,
+		commands: List<SsmCreateCommand>
+	): List<InvokeReturn> {
+		return ssmService.signsAndSend(chaincodeUri, signerName) {
+			commands.map { command ->
+				logger.info("Create ssm[${command.ssm.name}] with signer[$command.signerName]")
+				create(command.ssm)
+			}
+		}
+	}
+
+	suspend fun sendStart(
+		chaincodeUri: ChaincodeUri,
+		signerName: AgentName,
+		commands: List<SsmStartCommand>
+	): List<InvokeReturn> {
+		return ssmService.signsAndSend(chaincodeUri, signerName) {
+			commands.map { command ->
+				logger.info(
+					"Start session[${command.session.session}] ssm[${command.session.ssm}] with signer[$command.signerName]"
+				)
+				start(command.session)
+			}
+
+		}
+	}
+
+	suspend fun sendPerform(
+		chaincodeUri: ChaincodeUri,
+		signerName: AgentName,
+		commands: List<SsmPerformCommand>
+	): List<InvokeReturn> {
+		return ssmService.signsAndSend(chaincodeUri, signerName) {
+			commands.map { command ->
+				logger.info(
+					"Perform action[${command.action}] session[${command.context.session}] with signer[$command.signerName]"
+				)
+				perform(command.action, command.context)
+			}
+		}
+	}
+
+	private fun registerUser(agent: Agent): SsmCmd {
+		val cmd = RegisterCmd(agent)
+		return cmd.commandToSign()
+	}
+
+	private fun create(ssm: Ssm): SsmCmd {
+		val cmd = CreateCmd(ssm)
+		return cmd.commandToSign()
+	}
+
+	private fun start(session: SsmSession): SsmCmd {
+		val cmd = StartCmd(session)
+		return cmd.commandToSign()
+	}
+
+	private fun perform(action: String, context: SsmContext): SsmCmd {
+		val cmd = PerformCmd(action, context)
+		return cmd.commandToSign()
+	}
+
+}

--- a/c2-ssm/ssm-sdk/ssm-sdk-core/src/main/kotlin/ssm/sdk/core/SsmService.kt
+++ b/c2-ssm/ssm-sdk/ssm-sdk-core/src/main/kotlin/ssm/sdk/core/SsmService.kt
@@ -1,0 +1,56 @@
+package ssm.sdk.core
+
+import org.slf4j.LoggerFactory
+import ssm.chaincode.dsl.model.Agent
+import ssm.chaincode.dsl.model.AgentName
+import ssm.chaincode.dsl.model.Ssm
+import ssm.chaincode.dsl.model.SsmContext
+import ssm.chaincode.dsl.model.SsmSession
+import ssm.chaincode.dsl.model.uri.ChaincodeUri
+import ssm.sdk.core.invoke.command.CreateCmd
+import ssm.sdk.core.invoke.command.PerformCmd
+import ssm.sdk.core.invoke.command.RegisterCmd
+import ssm.sdk.core.invoke.command.StartCmd
+import ssm.sdk.core.ktor.SsmRequester
+import ssm.sdk.dsl.InvokeReturn
+import ssm.sdk.dsl.SsmCmd
+import ssm.sdk.dsl.SsmCmdSigned
+import ssm.sdk.sign.SsmCmdSigner
+
+class SsmService(
+	private val ssmRequester: SsmRequester,
+	private val ssmCmdSigner: SsmCmdSigner
+) {
+
+	suspend fun signAndSend(chaincodeUri: ChaincodeUri, signerName: AgentName, build: () -> SsmCmd): InvokeReturn {
+		return build().let { ssmCmd ->
+			sign(ssmCmd, signerName)
+		}.let { signed ->
+			send(chaincodeUri, signed)
+		}
+	}
+
+	suspend fun signsAndSend(
+		chaincodeUri: ChaincodeUri,
+		signerName: AgentName,
+		build: () -> List<SsmCmd>
+	): List<InvokeReturn> {
+		return build().map { ssmCmd ->
+			sign(ssmCmd, signerName)
+		}.let { signed ->
+			send(chaincodeUri, signed)
+		}
+	}
+
+	fun sign(command: SsmCmd, signerName: AgentName): SsmCmdSigned {
+		return ssmCmdSigner.sign(command, signerName)
+	}
+
+	suspend fun send(chaincodeUri: ChaincodeUri, ssmCommandSigned: SsmCmdSigned): InvokeReturn {
+		return ssmRequester.invoke(chaincodeUri, ssmCommandSigned)
+	}
+
+	suspend fun send(chaincodeUri: ChaincodeUri, ssmCommandSigneds: List<SsmCmdSigned>): List<InvokeReturn> {
+		return ssmRequester.invoke(chaincodeUri, ssmCommandSigneds)
+	}
+}

--- a/c2-ssm/ssm-sdk/ssm-sdk-core/src/main/kotlin/ssm/sdk/core/SsmServiceFactory.kt
+++ b/c2-ssm/ssm-sdk/ssm-sdk-core/src/main/kotlin/ssm/sdk/core/SsmServiceFactory.kt
@@ -10,7 +10,7 @@ import ssm.sdk.sign.SsmCmdSigner
 
 class SsmServiceFactory(
 	private var coopRepository: KtorRepository,
-	private var jsonConverter: JSONConverter,
+	private var jsonConverter: JSONConverterObjectMapper,
 ) {
 
 	fun buildQueryService(): SsmQueryService {
@@ -18,10 +18,15 @@ class SsmServiceFactory(
 	}
 
 	fun buildTxService(ssmCmdSigner: SsmCmdSigner): SsmTxService {
-		return SsmTxService(
-			SsmRequester(jsonConverter, coopRepository),
-			ssmCmdSigner
-		)
+		val ssmService = SsmService(SsmRequester(jsonConverter, coopRepository),
+			ssmCmdSigner)
+		return SsmTxService(ssmService)
+	}
+
+	fun buildCommandService(ssmCmdSigner: SsmCmdSigner): SsmCommandService {
+		val ssmService = SsmService(SsmRequester(jsonConverter, coopRepository),
+			ssmCmdSigner)
+		return SsmCommandService(ssmService)
 	}
 
 	companion object {
@@ -33,7 +38,7 @@ class SsmServiceFactory(
 
 		fun builder(config: SsmSdkConfig, bearerTokenHeaderProvider: BearerTokenAuthCredentials? = null): SsmServiceFactory {
 			val coopRepository = KtorRepository(config.baseUrl, bearerTokenHeaderProvider)
-			val converter: JSONConverter = JSONConverterObjectMapper()
+			val converter = JSONConverterObjectMapper()
 			return SsmServiceFactory(
 				coopRepository = coopRepository,
 				jsonConverter = converter,

--- a/c2-ssm/ssm-sdk/ssm-sdk-core/src/main/kotlin/ssm/sdk/core/SsmTxService.kt
+++ b/c2-ssm/ssm-sdk/ssm-sdk-core/src/main/kotlin/ssm/sdk/core/SsmTxService.kt
@@ -18,10 +18,40 @@ import ssm.sdk.dsl.SsmCmdSigned
 import ssm.sdk.sign.SsmCmdSigner
 
 class SsmTxService(
-	private val ssmRequester: SsmRequester,
-	private val ssmCmdSigner: SsmCmdSigner
+	private val ssmService: SsmService,
 ) {
 	private val logger = LoggerFactory.getLogger(SsmTxService::class.java)
+
+	suspend fun sendRegisterUser(chaincodeUri: ChaincodeUri, agent: Agent, signerName: AgentName): InvokeReturn {
+		logger.info("Register user[${agent.name}] with signer[$signerName]")
+		return ssmService.signAndSend(chaincodeUri, signerName) {
+			registerUser(agent)
+		}
+	}
+
+	suspend fun sendCreate(chaincodeUri: ChaincodeUri, ssm: Ssm, signerName: AgentName): InvokeReturn {
+		logger.info("Create ssm[${ssm.name}] with signer[$signerName]")
+		return ssmService.signAndSend(chaincodeUri, signerName) {
+			create(ssm)
+		}
+	}
+
+	suspend fun sendStart(chaincodeUri: ChaincodeUri, session: SsmSession, signerName: AgentName): InvokeReturn {
+		logger.info("Start session[${session.session}] ssm[${session.ssm}] with signer[$signerName]")
+		return ssmService.signAndSend(chaincodeUri, signerName) {
+			start(session)
+		}
+	}
+
+	suspend fun sendPerform(
+		chaincodeUri: ChaincodeUri, action: String, context: SsmContext, signerName: AgentName
+	): InvokeReturn {
+		logger.info("Perform action[${action}] session[${context.session}] with signer[$signerName]")
+		return ssmService.signAndSend(chaincodeUri, signerName) {
+			perform(action, context)
+		}
+	}
+
 
 	fun registerUser(agent: Agent): SsmCmd {
 		val cmd = RegisterCmd(agent)
@@ -33,7 +63,7 @@ class SsmTxService(
 		return cmd.commandToSign()
 	}
 
-	fun start( session: SsmSession): SsmCmd {
+	fun start(session: SsmSession): SsmCmd {
 		val cmd = StartCmd(session)
 		return cmd.commandToSign()
 	}
@@ -43,50 +73,4 @@ class SsmTxService(
 		return cmd.commandToSign()
 	}
 
-
-	suspend fun sendRegisterUser(chaincodeUri: ChaincodeUri, agent: Agent, signerName: AgentName): InvokeReturn? {
-		logger.info("Register user[${agent.name}] with signer[$signerName]")
-		return signAndSend(chaincodeUri, signerName) {
-			registerUser(agent)
-		}
-	}
-
-	suspend fun sendCreate(chaincodeUri: ChaincodeUri, ssm: Ssm, signerName: AgentName): InvokeReturn? {
-		logger.info("Create ssm[${ssm.name}] with signer[$signerName]")
-		return signAndSend(chaincodeUri, signerName) {
-			create(ssm)
-		}
-	}
-
-	suspend fun sendStart(chaincodeUri: ChaincodeUri, session: SsmSession, signerName: AgentName): InvokeReturn? {
-		logger.info("Start session[${session.session}] ssm[${session.ssm}] with signer[$signerName]")
-		return signAndSend(chaincodeUri, signerName) {
-			start(session)
-		}
-	}
-
-	suspend fun sendPerform(
-		chaincodeUri: ChaincodeUri, action: String, context: SsmContext, signerName: AgentName
-	): InvokeReturn {
-		logger.info("Perform action[${action}] session[${context.session}] with signer[$signerName]")
-		return signAndSend(chaincodeUri, signerName) {
-			perform(action, context)
-		}
-	}
-
-	suspend fun signAndSend(chaincodeUri: ChaincodeUri, signerName: AgentName, build: () -> SsmCmd): InvokeReturn {
-		return build().let { ssmCmd ->
-			sign(ssmCmd, signerName)
-		}.let { signed ->
-			send(chaincodeUri, signed)
-		}
-	}
-
-	fun sign(command: SsmCmd, signerName: AgentName): SsmCmdSigned {
-		return ssmCmdSigner.sign(command, signerName)
-	}
-
-	suspend fun send(chaincodeUri: ChaincodeUri, ssmCommandSigned: SsmCmdSigned): InvokeReturn {
-		return ssmRequester.invoke(chaincodeUri, ssmCommandSigned)
-	}
 }

--- a/c2-ssm/ssm-sdk/ssm-sdk-core/src/main/kotlin/ssm/sdk/core/command/SsmCreateCommand.kt
+++ b/c2-ssm/ssm-sdk/ssm-sdk-core/src/main/kotlin/ssm/sdk/core/command/SsmCreateCommand.kt
@@ -1,0 +1,7 @@
+package ssm.sdk.core.command
+
+import ssm.chaincode.dsl.model.Ssm
+
+data class SsmCreateCommand(
+    val ssm: Ssm,
+)

--- a/c2-ssm/ssm-sdk/ssm-sdk-core/src/main/kotlin/ssm/sdk/core/command/SsmPerformCommand.kt
+++ b/c2-ssm/ssm-sdk/ssm-sdk-core/src/main/kotlin/ssm/sdk/core/command/SsmPerformCommand.kt
@@ -1,0 +1,8 @@
+package ssm.sdk.core.command
+
+import ssm.chaincode.dsl.model.SsmContext
+
+data class SsmPerformCommand(
+    val action: String,
+    val context: SsmContext,
+)

--- a/c2-ssm/ssm-sdk/ssm-sdk-core/src/main/kotlin/ssm/sdk/core/command/SsmStartCommand.kt
+++ b/c2-ssm/ssm-sdk/ssm-sdk-core/src/main/kotlin/ssm/sdk/core/command/SsmStartCommand.kt
@@ -1,0 +1,7 @@
+package ssm.sdk.core.command
+
+import ssm.chaincode.dsl.model.SsmSession
+
+data class SsmStartCommand(
+    val session: SsmSession,
+)

--- a/c2-ssm/ssm-sdk/ssm-sdk-core/src/main/kotlin/ssm/sdk/core/command/UserRegisterCommand.kt
+++ b/c2-ssm/ssm-sdk/ssm-sdk-core/src/main/kotlin/ssm/sdk/core/command/UserRegisterCommand.kt
@@ -1,0 +1,7 @@
+package ssm.sdk.core.command
+
+import ssm.chaincode.dsl.model.Agent
+
+data class UserRegisterCommand(
+    val agent: Agent,
+)

--- a/c2-ssm/ssm-sdk/ssm-sdk-core/src/main/kotlin/ssm/sdk/core/ktor/SsmRequester.kt
+++ b/c2-ssm/ssm-sdk/ssm-sdk-core/src/main/kotlin/ssm/sdk/core/ktor/SsmRequester.kt
@@ -1,13 +1,16 @@
 package ssm.sdk.core.ktor
 
 import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.module.kotlin.readValue
 import org.slf4j.LoggerFactory
 import ssm.chaincode.dsl.model.uri.ChaincodeUri
 import ssm.sdk.core.invoke.builder.HasGet
 import ssm.sdk.core.invoke.builder.HasList
+import ssm.sdk.dsl.InvokeType
 import ssm.sdk.dsl.InvokeReturn
 import ssm.sdk.dsl.SsmCmdSigned
 import ssm.sdk.dsl.buildArgs
+import ssm.sdk.dsl.buildCommandArgs
 import ssm.sdk.json.JSONConverter
 import ssm.sdk.json.JsonUtils
 
@@ -21,10 +24,11 @@ class SsmRequester(
 	suspend fun <T> log(chaincodeUri: ChaincodeUri, value: String, query: HasGet, clazz: TypeReference<List<T>>): List<T> {
 		val args = query.queryArgs(value)
 		logger.info(
-			"Query[$QUERY] the blockchain in chaincode[${chaincodeUri.uri}] with fcn[${args.fcn}] with args:${args.args}",
+			"Query[${InvokeType.QUERY}] the blockchain in chaincode[${chaincodeUri.uri}] " +
+					"with fcn[${args.fcn}] with args:${args.args}",
 		)
 		val request = coopRepository.query(
-			cmd = QUERY,
+			cmd = InvokeType.QUERY.value,
 			fcn = args.fcn,
 			args = args.args,
 			channelId = chaincodeUri.channelId,
@@ -38,7 +42,7 @@ class SsmRequester(
 	suspend fun <T> query(chaincodeUri: ChaincodeUri, value: String, query: HasGet, clazz: Class<T>): T? {
 		val args = query.queryArgs(value)
 		val request = coopRepository.query(
-			cmd = QUERY,
+			cmd = InvokeType.QUERY.value,
 			fcn = args.fcn,
 			args = args.args,
 			channelId = chaincodeUri.channelId,
@@ -53,7 +57,7 @@ class SsmRequester(
 	suspend fun <T> list(chaincodeUri: ChaincodeUri, query: HasList, clazz: Class<T>): List<T> {
 		val args = query.listArgs()
 		val request = coopRepository.query(
-			cmd = QUERY,
+			cmd = InvokeType.QUERY.value,
 			fcn = args.fcn,
 			args = args.args,
 			channelId = chaincodeUri.channelId,
@@ -77,7 +81,7 @@ class SsmRequester(
         """.trimIndent()
 		)
 		return coopRepository.invoke(
-			cmd = INVOKE,
+			cmd = InvokeType.INVOKE,
 			fcn = invokeArgs.fcn,
 			args = invokeArgs.args,
 			channelId = chaincodeUri.channelId,
@@ -87,8 +91,23 @@ class SsmRequester(
 		}
 	}
 
-	companion object {
-		const val QUERY = "query"
-		const val INVOKE = "invoke"
+	@Throws(Exception::class)
+	suspend operator fun invoke(chaincodeUri: ChaincodeUri, cmds: List<SsmCmdSigned>): List<InvokeReturn> {
+		val args = cmds.map { cmd ->
+			val invokeArgs = cmd.buildCommandArgs(InvokeType.INVOKE, chaincodeUri)
+			logger.info(
+				"""
+				Invoke the blockchain in channel[${chaincodeUri.chaincodeId}]  with command[${invokeArgs.fcn}] 
+				with args:$invokeArgs
+			""".trimIndent()
+			)
+			invokeArgs
+		}
+
+		return coopRepository.invoke(
+			args
+		).let {
+			JsonUtils.mapper.readValue<List<InvokeReturn>>(it)
+		}
 	}
 }

--- a/c2-ssm/ssm-sdk/ssm-sdk-core/src/test/kotlin/ssm/sdk/core/invoke/command/CreateCommandTest.kt
+++ b/c2-ssm/ssm-sdk/ssm-sdk-core/src/test/kotlin/ssm/sdk/core/invoke/command/CreateCommandTest.kt
@@ -44,7 +44,7 @@ class CreateCommandTest {
 
 		val (fcn, args) = CreateCmd(ssm).invoke(signerUser.name, signer).buildArgs()
 
-		args.forEach(Consumer { s: String? -> println(s) })
+		args.forEach { s: String? -> println(s) }
 		/**
 		 * {
 		 * "InvokeArgs": [

--- a/c2-ssm/ssm-sdk/ssm-sdk-dsl/src/commonMain/kotlin/ssm/sdk/dsl/InvokeArgs.kt
+++ b/c2-ssm/ssm-sdk/ssm-sdk-dsl/src/commonMain/kotlin/ssm/sdk/dsl/InvokeArgs.kt
@@ -1,6 +1,22 @@
 package ssm.sdk.dsl
 
+import ssm.chaincode.dsl.model.ChaincodeId
+import ssm.chaincode.dsl.model.ChannelId
+import ssm.chaincode.dsl.model.uri.ChaincodeUri
+
 data class InvokeArgs(
 	val fcn: String,
 	val args: List<String>,
 )
+
+data class InvokeCommandArgs(
+	val cmd: InvokeType,
+	val fcn: String,
+	val args: List<String>,
+	val chaincodeUri: ChaincodeUri?
+)
+
+
+enum class InvokeType(val value: String) {
+		QUERY("query"), INVOKE("invoke")
+}

--- a/c2-ssm/ssm-sdk/ssm-sdk-dsl/src/commonMain/kotlin/ssm/sdk/dsl/SsmCmdSigned.kt
+++ b/c2-ssm/ssm-sdk/ssm-sdk-dsl/src/commonMain/kotlin/ssm/sdk/dsl/SsmCmdSigned.kt
@@ -1,5 +1,9 @@
 package ssm.sdk.dsl
 
+import ssm.chaincode.dsl.model.ChaincodeId
+import ssm.chaincode.dsl.model.ChannelId
+import ssm.chaincode.dsl.model.uri.ChaincodeUri
+
 typealias SignerName = String
 
 data class SsmCmdSigned(
@@ -11,4 +15,17 @@ data class SsmCmdSigned(
 fun SsmCmdSigned.buildArgs(): InvokeArgs {
 	return InvokeArgs(cmd.command.value,
 		listOfNotNull(cmd.performAction, cmd.json, signer, signature))
+}
+
+fun SsmCmdSigned.buildCommandArgs(
+	type: InvokeType,
+	chaincodeUri: ChaincodeUri
+	): InvokeCommandArgs {
+	val args = buildArgs()
+	return InvokeCommandArgs(
+		cmd = type,
+		chaincodeUri = chaincodeUri,
+		fcn = args.fcn,
+		args = args.args
+	)
 }

--- a/c2-ssm/ssm-sdk/ssm-sdk-json/src/main/kotlin/ssm/sdk/json/JSONConverter.kt
+++ b/c2-ssm/ssm-sdk/ssm-sdk-json/src/main/kotlin/ssm/sdk/json/JSONConverter.kt
@@ -1,5 +1,7 @@
 package ssm.sdk.json
 
+import com.fasterxml.jackson.core.type.TypeReference
+
 interface JSONConverter {
 	fun <T> toCompletableObjects(clazz: Class<T>, value: String): List<T>
 	fun <T> toCompletableObject(clazz: Class<T>, value: String): T?

--- a/c2-ssm/ssm-sdk/ssm-sdk-json/src/main/kotlin/ssm/sdk/json/JSONConverterObjectMapper.kt
+++ b/c2-ssm/ssm-sdk/ssm-sdk-json/src/main/kotlin/ssm/sdk/json/JSONConverterObjectMapper.kt
@@ -2,13 +2,17 @@ package ssm.sdk.json
 
 import com.fasterxml.jackson.core.type.TypeReference
 import java.io.IOException
+import java.lang.reflect.Type
 import java.util.concurrent.CompletionException
+import ssm.sdk.json.JsonUtils.mapper
 
 class JSONConverterObjectMapper : JSONConverter {
+
+
 	override fun <T> toCompletableObjects(clazz: Class<T>, value: String): List<T> {
-		val type: TypeReference<List<T>> = object : TypeReference<List<T>>() {}
-		return try {
-			JsonUtils.toObject(value, type)
+		try {
+			val type: TypeReference<List<T>> = object : TypeReference<List<T>>() {}
+			 return JsonUtils.toObject(value, type)
 		} catch (e: IOException) {
 			throw CompletionException("Error parsing response: $value", e)
 		}

--- a/c2-ssm/ssm-sdk/ssm-sdk-json/src/main/kotlin/ssm/sdk/json/JsonUtils.kt
+++ b/c2-ssm/ssm-sdk/ssm-sdk-json/src/main/kotlin/ssm/sdk/json/JsonUtils.kt
@@ -9,12 +9,13 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import java.io.IOException
 import java.io.Reader
 
 object JsonUtils {
 
-	private val mapper: ObjectMapper = ObjectMapper()
+	val mapper: ObjectMapper = ObjectMapper()
 		.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
 		.setSerializationInclusion(JsonInclude.Include.NON_NULL)
 		.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)

--- a/infra/docker-compose/.env_dev
+++ b/infra/docker-compose/.env_dev
@@ -2,7 +2,6 @@
 DOCKER_REPOSITORY=docker.io/komune/
 
 DOCKER_NETWORK=ssm-test-network
-VERSION_C2=0.18.0-SNAPSHOT
 
 #BCLAN
 BCLAN_COUCH_HOST=couchdb.bc-coop.bclan

--- a/infra/docker-compose/.env_dev
+++ b/infra/docker-compose/.env_dev
@@ -1,5 +1,5 @@
 #DOCKER_REPOSITORY=ghcr.io/komune-io/
-DOCKER_REPOSITORY=docker.io/komune/
+#DOCKER_REPOSITORY=docker.io/komune/
 
 DOCKER_NETWORK=ssm-test-network
 

--- a/infra/docker-compose/dev-compose.mk
+++ b/infra/docker-compose/dev-compose.mk
@@ -1,4 +1,5 @@
 DOCKER_COMPOSE_FILE = c2-sandbox c2-sandbox-gateway c2-sandbox-ssm c2-sandbox-ex02
+VERSION_C2 = $(shell cat VERSION)
 
 DOCKER_COMPOSE_PATH = infra/docker-compose
 DOCKER_COMPOSE_ENV = $(DOCKER_COMPOSE_PATH)/.env_dev

--- a/infra/docker-compose/docker-compose-c2-sandbox-gateway.yml
+++ b/infra/docker-compose/docker-compose-c2-sandbox-gateway.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   coop-rest-java:
     container_name: coop-rest-bclan-${DOCKER_NETWORK}
-    image: c2-sandbox-ssm-gateway:${VERSION_C2}
+    image: ${DOCKER_REPOSITORY}c2-sandbox-ssm-gateway:${VERSION_C2}
     environment:
       - i2_jwt-issuer-uri=
     ports:

--- a/infra/docker-compose/docker-compose-c2-sandbox-gateway.yml
+++ b/infra/docker-compose/docker-compose-c2-sandbox-gateway.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   coop-rest-java:
     container_name: coop-rest-bclan-${DOCKER_NETWORK}
-    image: ${DOCKER_REPOSITORY}c2-sandbox-ssm-gateway:${VERSION_C2}
+    image: c2-sandbox-ssm-gateway:${VERSION_C2}
     environment:
       - i2_jwt-issuer-uri=
     ports:

--- a/infra/docker-compose/docker-compose-c2-sandbox-gateway.yml
+++ b/infra/docker-compose/docker-compose-c2-sandbox-gateway.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   coop-rest-java:
     container_name: coop-rest-bclan-${DOCKER_NETWORK}
-    image: c2-sandbox-ssm-gateway
+    image: c2-sandbox-ssm-gateway:${VERSION_C2}
     environment:
       - i2_jwt-issuer-uri=
     ports:

--- a/infra/docker-compose/docker-compose-c2-sandbox-gateway.yml
+++ b/infra/docker-compose/docker-compose-c2-sandbox-gateway.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   coop-rest-java:
     container_name: coop-rest-bclan-${DOCKER_NETWORK}
-    image: c2-sandbox-ssm-gateway:${VERSION_C2}
+    image: c2-sandbox-ssm-gateway
     environment:
       - i2_jwt-issuer-uri=
     ports:

--- a/infra/docker-compose/docker-compose-c2-sandbox.yml
+++ b/infra/docker-compose/docker-compose-c2-sandbox.yml
@@ -18,7 +18,7 @@ services:
       - net
 
   couchdb.bc-coop.bclan:
-    container_name: couchdb-bclan-network-it
+    container_name: couchdb-bclan-${DOCKER_NETWORK}
     image: couchdb:3.1.2
     environment:
       - COUCHDB_USER=${BCLAN_COUCH_USER}

--- a/libs.mk
+++ b/libs.mk
@@ -6,6 +6,7 @@ lint:
 	./gradlew detekt
 
 build:
+	@make build -C c2-chaincode -e VERSION=$(VERSION)
 	VERSION=$(VERSION) ./gradlew clean build publishToMavenLocal -x test
 
 test-pre:

--- a/libs.mk
+++ b/libs.mk
@@ -6,7 +6,8 @@ lint:
 	./gradlew detekt
 
 build:
-	@make build -C c2-chaincode -e VERSION=$(VERSION)
+	# Build chaincode-api-gateway docker because it used in infra/dev/docker-compose-c2-sandbox-gateway.yml
+	@make -f docker.mk docker-chaincode-api-gateway-build
 	VERSION=$(VERSION) ./gradlew clean build publishToMavenLocal -x test
 
 test-pre:

--- a/libs.mk
+++ b/libs.mk
@@ -6,8 +6,7 @@ lint:
 	./gradlew detekt
 
 build:
-	# Build chaincode-api-gateway docker because it used in infra/dev/docker-compose-c2-sandbox-gateway.yml
-	@make -f docker.mk docker-chaincode-api-gateway-build
+	@make -f docker.mk build
 	VERSION=$(VERSION) ./gradlew clean build publishToMavenLocal -x test
 
 test-pre:


### PR DESCRIPTION
build(chaincode-api-auth): remove unnecessary dependencies and cleanup build.gradle.kts

feat(chaincode-api-gateway): add new endpoint 'invokeJson' to handle JSON requests
feat(chaincode-api-gateway): implement 'execute' method to handle multiple invoke requests concurrently
refactor(ChaincodeService.kt): refactor 'doInvoke' method to return InvokeReturn object instead of String
refactor(HeraclesConfigProps.kt): remove unnecessary println statement
style(SsmCommandStep.kt): change 'loadSignerAdmin' method visibility to private
refactor(ChaincodeUri.kt): make channelId and chaincodeId nullable in 'from' method
refactor(CouchdbSsmClient.kt): remove unnecessary println statement

The changes were made to improve code readability, remove unnecessary dependencies, add new functionality to handle JSON requests, refactor methods for better performance, and clean up code by removing unnecessary print statements.

feat(ssm-sdk): add SsmCommandService, SsmService, and SsmServiceFactory classes The SsmCommandService class provides methods for sending various commands related to SSM operations. The SsmService class handles signing and sending commands to the chaincode. The SsmServiceFactory class is responsible for building instances of SsmQueryService, SsmTxService, and SsmCommandService based on the provided dependencies. These classes enhance the functionality of the SSM SDK by encapsulating command execution logic and service instantiation.

refactor(SsmTxService.kt): refactor send methods to use ssmService for signing and sending commands feat(SsmTxService.kt): add new command classes for SsmCreateCommand, SsmPerformCommand, SsmStartCommand, and UserRegisterCommand The changes refactor the send methods in SsmTxService to utilize the ssmService for signing and sending commands, improving code readability and maintainability. Additionally, new command classes are added to enhance the structure and organization of the codebase, providing better separation of concerns and scalability.

feat(ssm-sdk): introduce InvokeType enum to improve readability and maintainability of SsmRequester class refactor(ssm-sdk): replace hardcoded string constants with InvokeType enum values for better consistency and clarity The changes introduce an InvokeType enum to represent the types of operations in the SsmRequester class, improving code readability and maintainability. Hardcoded string constants like "query" and "invoke" are replaced with enum values, making the code more consistent and easier to understand.

feat(SsmClientArrayTest.kt): add SsmClientArrayTest class for testing SsmClient functionality The SsmClientArrayTest class is added to the project to facilitate testing of the SsmClient functionality. This class includes various test methods for interacting with the SsmClient, such as listing admins, registering users, creating sessions, performing actions, and retrieving session information. The class also includes setup methods for initializing necessary objects and variables for testing purposes.

feat: add @Order annotation to listSession function for test ordering The @Order(150) annotation is added to the listSession function to specify the order in which the test should be executed. This helps in organizing and controlling the sequence of test execution, ensuring that the tests run in a predictable order.

fix(tests): remove unnecessary runBlocking calls and fix lambda syntax in SsmClientItTest.kt refactor(core): add new InvokeCommandArgs data class and buildCommandArgs function in SsmCmdSigned.kt for improved readability and maintainability refactor(json): use jacksonObjectMapper in JsonUtils.kt for better performance and consistency The changes were made to improve the code quality and readability. Unnecessary runBlocking calls were removed in the tests to simplify the code. Lambda syntax was fixed in SsmClientItTest.kt for better clarity. A new data class InvokeCommandArgs and a function buildCommandArgs were added in SsmCmdSigned.kt to enhance code structure. JacksonObjectMapper was used in JsonUtils.kt for better performance and consistency in JSON handling.

chore(infra): update docker-compose configuration files to remove VERSION_C2 variable and use dynamic version from VERSION file The VERSION_C2 variable is removed from the .env_dev file and dev-compose.mk file. Instead, the dynamic version is now fetched from the VERSION file using the $(shell cat VERSION) command. This change ensures that the version used in the docker-compose configuration is always up to date and consistent with the project's versioning.