### PR TITLE
test(libs.mk): add additional commands to start and log sandbox services for testing

### DIFF
--- a/infra/docker-compose/.env_dev
+++ b/infra/docker-compose/.env_dev
@@ -1,4 +1,4 @@
-#DOCKER_REPOSITORY=ghcr.io/komune-io/
+DOCKER_REPOSITORY=ghcr.io/komune-io/
 #DOCKER_REPOSITORY=docker.io/komune/
 
 DOCKER_NETWORK=ssm-test-network

--- a/infra/docker-compose/dev-compose.mk
+++ b/infra/docker-compose/dev-compose.mk
@@ -4,7 +4,7 @@ VERSION_C2 = $(shell cat VERSION)
 DOCKER_COMPOSE_PATH = infra/docker-compose
 DOCKER_COMPOSE_ENV = $(DOCKER_COMPOSE_PATH)/.env_dev
 .PHONY: $(DOCKER_COMPOSE_FILE)
-ACTIONS = up down logs
+ACTIONS = up down logs pull
 
 include $(DOCKER_COMPOSE_ENV)
 export
@@ -34,7 +34,9 @@ dev-service-action:
 	elif [ "$(ACTION)" = "down" ]; then \
 		docker compose --env-file $(DOCKER_COMPOSE_ENV) -f $(DOCKER_COMPOSE_PATH)/docker-compose-$(SERVICE).yml down -v; \
 	elif [ "$(ACTION)" = "logs" ]; then \
-		docker compose --env-file $(DOCKER_COMPOSE_ENV) -f $(DOCKER_COMPOSE_PATH)/docker-compose-$(SERVICE).yml logs; \
+		docker compose --env-file $(DOCKER_COMPOSE_ENV) -f $(DOCKER_COMPOSE_PATH)/docker-compose-$(SERVICE).yml logs -f; \
+	elif [ "$(ACTION)" = "pull" ]; then \
+		docker compose --env-file $(DOCKER_COMPOSE_ENV) -f $(DOCKER_COMPOSE_PATH)/docker-compose-$(SERVICE).yml pull; \
 	else \
 		echo 'No valid action: $(ACTION).'; \
 		echo 'Available actions are:'; \

--- a/infra/docker-compose/dev-compose.mk
+++ b/infra/docker-compose/dev-compose.mk
@@ -34,7 +34,7 @@ dev-service-action:
 	elif [ "$(ACTION)" = "down" ]; then \
 		docker compose --env-file $(DOCKER_COMPOSE_ENV) -f $(DOCKER_COMPOSE_PATH)/docker-compose-$(SERVICE).yml down -v; \
 	elif [ "$(ACTION)" = "logs" ]; then \
-		docker compose --env-file $(DOCKER_COMPOSE_ENV) -f $(DOCKER_COMPOSE_PATH)/docker-compose-$(SERVICE).yml logs -f; \
+		docker compose --env-file $(DOCKER_COMPOSE_ENV) -f $(DOCKER_COMPOSE_PATH)/docker-compose-$(SERVICE).yml logs; \
 	else \
 		echo 'No valid action: $(ACTION).'; \
 		echo 'Available actions are:'; \

--- a/infra/docker-compose/docker-compose-c2-sandbox.yml
+++ b/infra/docker-compose/docker-compose-c2-sandbox.yml
@@ -18,7 +18,7 @@ services:
       - net
 
   couchdb.bc-coop.bclan:
-    container_name: couchdb-bclan-${DOCKER_NETWORK}
+    container_name: couchdb-bclan-network-it
     image: couchdb:3.1.2
     environment:
       - COUCHDB_USER=${BCLAN_COUCH_USER}

--- a/libs.mk
+++ b/libs.mk
@@ -9,17 +9,14 @@ build:
 	VERSION=$(VERSION) ./gradlew clean build publishToMavenLocal -x test
 
 test-pre:
+	@make dev pull
 	@make dev up
-	@echo "///////////////////////1"
-	@make dev c2-sandbox logs
 	@echo "///////////////////////2"
 	@make dev c2-sandbox-ssm logs
 	@echo "///////////////////////3"
 	@make dev c2-sandbox-ex02 logs
 	@echo "///////////////////////4"
 	@make dev up
-	@echo "///////////////////////5"
-	@make dev c2-sandbox logs
 	@echo "///////////////////////6"
 	@make dev c2-sandbox-ssm logs
 	@echo "///////////////////////7"

--- a/libs.mk
+++ b/libs.mk
@@ -11,11 +11,21 @@ build:
 
 test-pre:
 	@make dev up
+	@echo "///////////////////////1"
+	@make dev c2-sandbox logs
+	@echo "///////////////////////2"
 	@make dev c2-sandbox-ssm logs
+	@echo "///////////////////////3"
 	@make dev c2-sandbox-ex02 logs
+	@echo "///////////////////////4"
 	@make dev up
+	@echo "///////////////////////5"
+	@make dev c2-sandbox logs
+	@echo "///////////////////////6"
 	@make dev c2-sandbox-ssm logs
+	@echo "///////////////////////7"
 	@make dev c2-sandbox-ex02 logs
+	@echo "///////////////////////8"
 	sudo echo "127.0.0.1 ca.bc-coop.bclan" | sudo tee -a /etc/hosts
 	sudo echo "127.0.0.1 peer0.bc-coop.bclan" | sudo tee -a /etc/hosts
 	sudo echo "127.0.0.1 orderer.bclan" | sudo tee -a /etc/hosts

--- a/libs.mk
+++ b/libs.mk
@@ -12,7 +12,10 @@ build:
 test-pre:
 	@make dev up
 	@make dev c2-sandbox-ssm logs
+	@make dev c2-sandbox-ex02 logs
 	@make dev up
+	@make dev c2-sandbox-ssm logs
+	@make dev c2-sandbox-ex02 logs
 	sudo echo "127.0.0.1 ca.bc-coop.bclan" | sudo tee -a /etc/hosts
 	sudo echo "127.0.0.1 peer0.bc-coop.bclan" | sudo tee -a /etc/hosts
 	sudo echo "127.0.0.1 orderer.bclan" | sudo tee -a /etc/hosts

--- a/libs.mk
+++ b/libs.mk
@@ -6,7 +6,6 @@ lint:
 	./gradlew detekt
 
 build:
-	@make -f docker.mk build
 	VERSION=$(VERSION) ./gradlew clean build publishToMavenLocal -x test
 
 test-pre:


### PR DESCRIPTION
The additional commands added to the test-pre target in libs.mk file are necessary to start and log the c2-sandbox-ex02 service for testing purposes. This ensures that all required services are properly started and logged before running tests, improving the reliability and completeness of the testing process.