### PR TITLE
ci(dev.yml): add workflow_dispatch trigger to manually run the workflow

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,6 +1,7 @@
 name: Dev
 
 on:
+  workflow_dispatch:
   pull_request:
     types: [opened, synchronize, labeled]
   push:


### PR DESCRIPTION
By adding the workflow_dispatch trigger, users can now manually run the workflow in addition to the existing triggers like pull_request and push. This provides more flexibility and control over when the workflow should be executed.