### PR TITLE
refactor(SSMFunctionClient.kt): refactor ssmClient function to use GlobalScope.promise for better coroutine handling

### DIFF
--- a/c2-ssm/ssm-chaincode/ssm-chaincode-f2-client/src/jsMain/kotlin/ssm/chaincode/f2/client/SSMFunctionClient.kt
+++ b/c2-ssm/ssm-chaincode/ssm-chaincode-f2-client/src/jsMain/kotlin/ssm/chaincode/f2/client/SSMFunctionClient.kt
@@ -5,12 +5,18 @@ import f2.client.ktor.F2ClientBuilder
 import f2.client.ktor.Protocol
 import f2.client.ktor.get
 import kotlin.js.Promise
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.promise
+
+@JsExport
+actual open class SSMFunctionClient actual constructor(client: F2Client) : SSMRemoteFunction
 
 @JsExport
 @JsName("ssmClient")
-fun ssmClient(protocol: Protocol, host: String, port: Int, path: String? = null): Promise<SSMFunctionClient> =
-	F2ClientBuilder.get(protocol, host, port, path).then { s2Client ->
+fun ssmClient(
+	protocol: Protocol, host: String, port: Int, path: String? = null
+): Promise<SSMFunctionClient> = GlobalScope.promise {
+	F2ClientBuilder.get(protocol, host, port, path).let { s2Client ->
 		SSMFunctionClient(s2Client)
 	}
-
-actual open class SSMFunctionClient actual constructor(val client: F2Client) : SSMRemoteFunction
+}


### PR DESCRIPTION
The ssmClient function in SSMFunctionClient.kt has been refactored to use GlobalScope.promise for better coroutine handling. This change improves the readability and maintainability of the code by utilizing Kotlin coroutines effectively.