### PR TITLE
build(gradle.kts): add Kotlin serialization plugin to build scripts

### DIFF
--- a/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/build.gradle.kts
+++ b/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
 	id("io.komune.fixers.gradle.kotlin.mpp")
 	id("io.komune.fixers.gradle.publish")
+	kotlin("plugin.serialization")
 //	id("dev.petuska.npm.publish")
 }
 

--- a/c2-ssm/ssm-couchdb/ssm-couchdb-dsl/build.gradle.kts
+++ b/c2-ssm/ssm-couchdb/ssm-couchdb-dsl/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
 	id("io.komune.fixers.gradle.kotlin.mpp")
 	id("io.komune.fixers.gradle.publish")
+	kotlin("plugin.serialization")
 //	id("dev.petuska.npm.publish")
 }
 

--- a/c2-ssm/ssm-data/ssm-data-dsl/build.gradle.kts
+++ b/c2-ssm/ssm-data/ssm-data-dsl/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
 	id("io.komune.fixers.gradle.kotlin.mpp")
 	id("io.komune.fixers.gradle.publish")
+	kotlin("plugin.serialization")
 }
 
 dependencies {


### PR DESCRIPTION
Add the Kotlin serialization plugin to the build scripts for the ssm-chaincode-dsl, ssm-couchdb-dsl, and ssm-data-dsl modules. This enables support for Kotlin serialization, which is necessary for handling JSON and other serialization tasks within these modules.