### PR TITLE
Remove Redundant @Serializable Annotations and Add Kotlin Serialization Plugin

### DIFF
--- a/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/SsmChaincodeQueries.kt
+++ b/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/SsmChaincodeQueries.kt
@@ -29,7 +29,6 @@ import ssm.chaincode.dsl.query.SsmListUserQueryFunction
  * @title Query function
  * @parent [ssm.chaincode.dsl.SsmChaincodeD2]
  */
-@Serializable
 @JsExport
 @JsName("SsmChaincodeQueries")
 interface SsmChaincodeQueries {

--- a/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/SsmQueryDTO.kt
+++ b/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/SsmQueryDTO.kt
@@ -7,7 +7,6 @@ import kotlin.js.JsName
 import kotlinx.serialization.Serializable
 import ssm.chaincode.dsl.model.uri.ChaincodeUri
 
-@Serializable
 @JsExport
 @JsName("SsmQueryDTO")
 interface SsmQueryDTO : Query {
@@ -18,14 +17,12 @@ interface SsmQueryDTO : Query {
 	val chaincodeUri: ChaincodeUri
 }
 
-@Serializable
 @JsExport
 @JsName("SsmItemResultDTO")
 interface SsmItemResultDTO<T> : Event {
 	val item: T?
 }
 
-@Serializable
 @JsExport
 @JsName("SsmItemsResultDTO")
 interface SsmItemsResultDTO<T> : Event {

--- a/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/blockchain/BlockDTO.kt
+++ b/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/blockchain/BlockDTO.kt
@@ -6,7 +6,6 @@ import kotlinx.serialization.Serializable
 
 typealias BlockId = String
 
-@Serializable
 @JsExport
 @JsName("BlockDTO")
 interface BlockDTO {

--- a/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/blockchain/IdentitiesInfoDTO.kt
+++ b/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/blockchain/IdentitiesInfoDTO.kt
@@ -4,7 +4,6 @@ import kotlin.js.JsExport
 import kotlin.js.JsName
 import kotlinx.serialization.Serializable
 
-@Serializable
 @JsExport
 @JsName("IdentitiesInfoDTO")
 interface IdentitiesInfoDTO {

--- a/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/blockchain/TransactionDTO.kt
+++ b/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/blockchain/TransactionDTO.kt
@@ -4,7 +4,6 @@ import kotlin.js.JsExport
 import kotlin.js.JsName
 import kotlinx.serialization.Serializable
 
-@Serializable
 @JsExport
 @JsName("TransactionDTO")
 interface TransactionDTO {
@@ -67,6 +66,7 @@ interface TransactionDTO {
  * @parent [ssm.chaincode.dsl.SsmChaincodeD2Model]
  * @title SSM-CHAINCODE/Blockchain Content
  */
+@Serializable
 @JsName("Transaction")
 @JsExport
 class Transaction(

--- a/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/config/InvokeChunkedProps.kt
+++ b/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/config/InvokeChunkedProps.kt
@@ -10,7 +10,9 @@ import kotlinx.coroutines.flow.flatMapMerge
 import kotlinx.coroutines.flow.flattenMerge
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
 
+@Serializable
 class InvokeChunkedProps(
     val size: Int = 128
 )

--- a/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/config/SsmChaincodePropertiesDTO.kt
+++ b/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/config/SsmChaincodePropertiesDTO.kt
@@ -10,7 +10,6 @@ import kotlinx.serialization.Serializable
  * @example "ssm"
  * @parent [ssm.chaincode.dsl.SsmChaincodeD2Model]
  */
-@Serializable
 @JsExport
 @JsName("SsmChaincodePropertiesDTO")
 interface SsmChaincodePropertiesDTO {

--- a/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/model/Agent.kt
+++ b/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/model/Agent.kt
@@ -6,7 +6,6 @@ import kotlinx.serialization.Serializable
 
 typealias AgentName = String
 
-@Serializable
 @JsExport
 @JsName("AgentDTO")
 interface AgentDTO {

--- a/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/model/Chaincode.kt
+++ b/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/model/Chaincode.kt
@@ -12,7 +12,6 @@ import kotlinx.serialization.Serializable
  */
 typealias ChaincodeId = String
 
-@Serializable
 @JsExport
 @JsName("ChaincodeDTO")
 interface ChaincodeDTO {

--- a/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/model/Ssm.kt
+++ b/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/model/Ssm.kt
@@ -12,7 +12,6 @@ import kotlinx.serialization.Serializable
  */
 typealias SsmName = String
 
-@Serializable
 @JsExport
 @JsName("SsmDTO")
 interface SsmDTO {

--- a/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/model/SsmContext.kt
+++ b/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/model/SsmContext.kt
@@ -4,7 +4,6 @@ import kotlin.js.JsExport
 import kotlin.js.JsName
 import kotlinx.serialization.Serializable
 
-@Serializable
 @JsExport
 @JsName("SsmContextDTO")
 interface SsmContextDTO : WithPrivate {

--- a/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/model/SsmGrant.kt
+++ b/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/model/SsmGrant.kt
@@ -4,7 +4,6 @@ import kotlin.js.JsExport
 import kotlin.js.JsName
 import kotlinx.serialization.Serializable
 
-@Serializable
 @JsExport
 @JsName("SsmGrantDTO")
 interface SsmGrantDTO {
@@ -22,7 +21,6 @@ data class SsmGrant(
 	val credits: Map<String, Credit>,
 )
 
-@Serializable
 @JsExport
 @JsName("CreditDTO")
 interface CreditDTO {

--- a/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/model/SsmSession.kt
+++ b/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/model/SsmSession.kt
@@ -6,7 +6,6 @@ import kotlinx.serialization.Serializable
 import ssm.chaincode.dsl.model.uri.ChaincodeUri
 import ssm.chaincode.dsl.model.uri.SsmUri
 
-@Serializable
 @JsExport
 @JsName("SsmSessionDTO")
 interface SsmSessionDTO : WithPrivate {

--- a/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/model/SsmSessionState.kt
+++ b/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/model/SsmSessionState.kt
@@ -2,13 +2,13 @@ package ssm.chaincode.dsl.model
 
 import kotlin.js.JsExport
 import kotlin.js.JsName
+import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
 import ssm.chaincode.dsl.model.uri.ChaincodeUri
 import ssm.chaincode.dsl.model.uri.SsmUri
 
 typealias SessionName = String
 
-@Serializable
 @JsExport
 @JsName("SsmSessionStateDTO")
 interface SsmSessionStateDTO : SsmSessionDTO, WithPrivate {
@@ -51,6 +51,7 @@ data class SsmSessionState(
 	override val ssm: SsmName?,
 	override val session: SessionName,
 	override val roles: Map<String, String>?,
+	@Contextual
 	override val public: Any?,
 	override val private: Map<String, String>? = hashMapOf(),
 	override val origin: SsmTransition?,

--- a/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/model/SsmSessionStateLog.kt
+++ b/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/model/SsmSessionStateLog.kt
@@ -5,7 +5,6 @@ import kotlin.js.JsName
 import kotlinx.serialization.Serializable
 import ssm.chaincode.dsl.blockchain.TransactionId
 
-@Serializable
 @JsExport
 @JsName("SsmSessionStateLogDTO")
 interface SsmSessionStateLogDTO {

--- a/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/model/SsmTransition.kt
+++ b/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/model/SsmTransition.kt
@@ -7,7 +7,6 @@ import kotlinx.serialization.Serializable
 typealias SsmAction = String
 typealias SsmRole = String
 
-@Serializable
 @JsExport
 @JsName("SsmTransitionDTO")
 interface SsmTransitionDTO {

--- a/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/model/WithPrivate.kt
+++ b/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/model/WithPrivate.kt
@@ -4,7 +4,6 @@ import kotlin.js.JsExport
 import kotlin.js.JsName
 import kotlinx.serialization.Serializable
 
-@Serializable
 @JsExport
 @JsName("WithPrivate")
 interface WithPrivate {

--- a/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/model/uri/ChaincodeUri.kt
+++ b/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/model/uri/ChaincodeUri.kt
@@ -7,7 +7,6 @@ import ssm.chaincode.dsl.model.ChaincodeId
 import ssm.chaincode.dsl.model.ChannelId
 import ssm.chaincode.dsl.model.SsmName
 
-@Serializable
 @JsExport
 @JsName("ChaincodeUriDTO")
 interface ChaincodeUriDTO {

--- a/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/model/uri/SsmUri.kt
+++ b/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/model/uri/SsmUri.kt
@@ -12,7 +12,6 @@ typealias SsmVersion = String
 
 const val DEFAULT_VERSION = "1.0.0"
 
-@Serializable
 @JsExport
 @JsName("SsmUriDTO")
 interface SsmUriDTO {

--- a/c2-ssm/ssm-couchdb/ssm-couchdb-dsl/src/commonMain/kotlin/ssm/couchdb/dsl/SsmCouchDbQueries.kt
+++ b/c2-ssm/ssm-couchdb/ssm-couchdb-dsl/src/commonMain/kotlin/ssm/couchdb/dsl/SsmCouchDbQueries.kt
@@ -25,7 +25,6 @@ import ssm.couchdb.dsl.query.CouchdbUserListQueryFunction
  * @title Query function
  * @parent [CouchdbSsmD2]
  */
-@Serializable
 @JsExport
 @JsName("SsmCouchDbQueries")
 interface SsmCouchDbQueries {

--- a/c2-ssm/ssm-couchdb/ssm-couchdb-dsl/src/commonMain/kotlin/ssm/couchdb/dsl/model/Database.kt
+++ b/c2-ssm/ssm-couchdb/ssm-couchdb-dsl/src/commonMain/kotlin/ssm/couchdb/dsl/model/Database.kt
@@ -13,7 +13,6 @@ typealias DatabaseName = String
  * @title Database
  * @parent [ssm.couchdb.dsl.CouchdbSsmD2Model]
  */
-@Serializable
 @JsExport
 @JsName("DatabaseDTO")
 interface DatabaseDTO {

--- a/c2-ssm/ssm-couchdb/ssm-couchdb-dsl/src/commonMain/kotlin/ssm/couchdb/dsl/model/DatabaseChanges.kt
+++ b/c2-ssm/ssm-couchdb/ssm-couchdb-dsl/src/commonMain/kotlin/ssm/couchdb/dsl/model/DatabaseChanges.kt
@@ -2,6 +2,7 @@ package ssm.couchdb.dsl.model
 
 import kotlin.js.JsExport
 import kotlin.js.JsName
+import kotlinx.serialization.Contextual
 import kotlinx.serialization.Serializable
 
 typealias ChangeEventId = String
@@ -13,7 +14,6 @@ typealias ChangeEventId = String
  * @title Database
  * @parent [ssm.couchdb.dsl.CouchdbSsmD2Model]
  */
-@Serializable
 @JsExport
 @JsName("DatabaseChangesDTO")
 interface DatabaseChangesDTO {
@@ -22,7 +22,6 @@ interface DatabaseChangesDTO {
 	val objectId: String
 }
 
-@Serializable
 @JsExport
 @JsName("DatabaseChanges")
 class DatabaseChanges(

--- a/c2-ssm/ssm-couchdb/ssm-couchdb-dsl/src/commonMain/kotlin/ssm/couchdb/dsl/query/CouchdbAdminListQuery.kt
+++ b/c2-ssm/ssm-couchdb/ssm-couchdb-dsl/src/commonMain/kotlin/ssm/couchdb/dsl/query/CouchdbAdminListQuery.kt
@@ -24,7 +24,6 @@ typealias CouchdbAdminListQueryFunction = F2Function<CouchdbAdminListQueryDTO, C
  * @d2 model
  * @parent [CouchdbAdminListQueryFunction]
  */
-@Serializable
 @JsExport
 @JsName("CouchdbAdminListQueryDTO")
 interface CouchdbAdminListQueryDTO : Query {
@@ -39,7 +38,6 @@ interface CouchdbAdminListQueryDTO : Query {
  * @title Get all admins: Result
  * @parent [CouchdbAdminListQueryFunction]
  */
-@Serializable
 @JsExport
 @JsName("CouchdbAdminListQueryResultDTO")
 interface CouchdbAdminListQueryResultDTO : Event {

--- a/c2-ssm/ssm-couchdb/ssm-couchdb-dsl/src/commonMain/kotlin/ssm/couchdb/dsl/query/CouchdbChaincodeListQuery.kt
+++ b/c2-ssm/ssm-couchdb/ssm-couchdb-dsl/src/commonMain/kotlin/ssm/couchdb/dsl/query/CouchdbChaincodeListQuery.kt
@@ -23,7 +23,6 @@ typealias CouchdbChaincodeListQueryFunction
  * @d2 model
  * @parent [CouchdbChaincodeListQueryFunction]
  */
-@Serializable
 @JsExport
 @JsName("CouchdbChaincodeListQueryDTO")
 interface CouchdbChaincodeListQueryDTO : Query
@@ -33,7 +32,6 @@ interface CouchdbChaincodeListQueryDTO : Query
  * @title Get all chaincodes: Result
  * @parent [CouchdbChaincodeListQueryFunction]
  */
-@Serializable
 @JsExport
 @JsName("CouchdbChaincodeListQueryResultDTO")
 interface CouchdbChaincodeListQueryResultDTO : Event {

--- a/c2-ssm/ssm-couchdb/ssm-couchdb-dsl/src/commonMain/kotlin/ssm/couchdb/dsl/query/CouchdbDatabaseGetChangesQuery.kt
+++ b/c2-ssm/ssm-couchdb/ssm-couchdb-dsl/src/commonMain/kotlin/ssm/couchdb/dsl/query/CouchdbDatabaseGetChangesQuery.kt
@@ -28,7 +28,6 @@ typealias CouchdbDatabaseGetChangesQueryFunction
  * @d2 model
  * @parent [CouchdbDatabaseGetQueryFunction]
  */
-@Serializable
 @JsExport
 @JsName("CouchdbDatabaseGetChangesQueryDTO")
 interface CouchdbDatabaseGetChangesQueryDTO : Query {
@@ -63,7 +62,6 @@ interface CouchdbDatabaseGetChangesQueryDTO : Query {
  * @title Get Database: Result
  * @parent [CouchdbDatabaseGetQueryFunction]
  */
-@Serializable
 @JsExport
 @JsName("CouchdbDatabaseGetChangesQueryResultDTO")
 interface CouchdbDatabaseGetChangesQueryResultDTO : Event {
@@ -86,7 +84,6 @@ class CouchdbDatabaseGetChangesQuery(
 	override val limit: Long?,
 ) : CouchdbDatabaseGetChangesQueryDTO
 
-@Serializable
 @JsExport
 @JsName("CouchdbDatabaseGetChangesQueryResult")
 class CouchdbDatabaseGetChangesQueryResult(

--- a/c2-ssm/ssm-couchdb/ssm-couchdb-dsl/src/commonMain/kotlin/ssm/couchdb/dsl/query/CouchdbDatabaseGetQuery.kt
+++ b/c2-ssm/ssm-couchdb/ssm-couchdb-dsl/src/commonMain/kotlin/ssm/couchdb/dsl/query/CouchdbDatabaseGetQuery.kt
@@ -24,7 +24,6 @@ typealias CouchdbDatabaseGetQueryFunction = F2Function<CouchdbDatabaseGetQueryDT
  * @d2 model
  * @parent [CouchdbDatabaseGetQueryFunction]
  */
-@Serializable
 @JsExport
 @JsName("CouchdbDatabaseGetQueryDTO")
 interface CouchdbDatabaseGetQueryDTO : Query {
@@ -44,7 +43,6 @@ interface CouchdbDatabaseGetQueryDTO : Query {
  * @title Get Database: Result
  * @parent [CouchdbDatabaseGetQueryFunction]
  */
-@Serializable
 @JsExport
 @JsName("CouchdbDatabaseGetQueryResultDTO")
 interface CouchdbDatabaseGetQueryResultDTO : Event {

--- a/c2-ssm/ssm-couchdb/ssm-couchdb-dsl/src/commonMain/kotlin/ssm/couchdb/dsl/query/CouchdbDatabaseListQuery.kt
+++ b/c2-ssm/ssm-couchdb/ssm-couchdb-dsl/src/commonMain/kotlin/ssm/couchdb/dsl/query/CouchdbDatabaseListQuery.kt
@@ -24,7 +24,6 @@ typealias CouchdbDatabaseListQueryFunction = F2Function<CouchdbDatabaseListQuery
  * @d2 model
  * @parent [CouchdbDatabaseListQueryFunction]
  */
-@Serializable
 @JsExport
 @JsName("CouchdbDatabaseListQueryDTO")
 interface CouchdbDatabaseListQueryDTO : PageQueryDTO {
@@ -44,7 +43,6 @@ interface CouchdbDatabaseListQueryDTO : PageQueryDTO {
  * @title Results
  * @parent [CouchdbDatabaseListQueryFunction]
  */
-@Serializable
 @JsExport
 @JsName("CouchdbDatabaseListQueryResultDTO")
 interface CouchdbDatabaseListQueryResultDTO : PageQueryResultDTO<DatabaseDTO> {

--- a/c2-ssm/ssm-couchdb/ssm-couchdb-dsl/src/commonMain/kotlin/ssm/couchdb/dsl/query/CouchdbSsmGetQuery.kt
+++ b/c2-ssm/ssm-couchdb/ssm-couchdb-dsl/src/commonMain/kotlin/ssm/couchdb/dsl/query/CouchdbSsmGetQuery.kt
@@ -27,7 +27,6 @@ typealias CouchdbSsmGetQueryFunction = F2Function<CouchdbSsmGetQuery, CouchdbSsm
  * @parent [CouchdbSsmGetQueryFunction]
  * @title Parameters
  */
-@Serializable
 @JsExport
 @JsName("CouchdbSsmGetQueryDTO")
 interface CouchdbSsmGetQueryDTO : Query {
@@ -53,7 +52,6 @@ interface CouchdbSsmGetQueryDTO : Query {
  * @order 30
  * @title Result
  */
-@Serializable
 @JsExport
 @JsName("CouchdbSsmGetQueryResultDTO")
 interface CouchdbSsmGetQueryResultDTO: Event {

--- a/c2-ssm/ssm-couchdb/ssm-couchdb-dsl/src/commonMain/kotlin/ssm/couchdb/dsl/query/CouchdbSsmListQuery.kt
+++ b/c2-ssm/ssm-couchdb/ssm-couchdb-dsl/src/commonMain/kotlin/ssm/couchdb/dsl/query/CouchdbSsmListQuery.kt
@@ -26,7 +26,6 @@ typealias CouchdbSsmListQueryFunction = F2Function<CouchdbSsmListQuery, CouchdbS
  * @parent [CouchdbSsmListQueryFunction]
  * @title Parameters
  */
-@Serializable
 @JsExport
 @JsName("CouchdbSsmListQueryDTO")
 interface CouchdbSsmListQueryDTO : PageQueryDTO {
@@ -46,7 +45,6 @@ interface CouchdbSsmListQueryDTO : PageQueryDTO {
  * @order 30
  * @title Result
  */
-@Serializable
 @JsExport
 @JsName("CouchdbSsmListQueryResultDTO")
 interface CouchdbSsmListQueryResultDTO: PageQueryResultDTO<SsmDTO> {

--- a/c2-ssm/ssm-couchdb/ssm-couchdb-dsl/src/commonMain/kotlin/ssm/couchdb/dsl/query/CouchdbSsmSessionStateGetQuery.kt
+++ b/c2-ssm/ssm-couchdb/ssm-couchdb-dsl/src/commonMain/kotlin/ssm/couchdb/dsl/query/CouchdbSsmSessionStateGetQuery.kt
@@ -22,7 +22,6 @@ import ssm.chaincode.dsl.model.uri.ChaincodeUriDTO
 typealias CouchdbSsmSessionStateGetQueryFunction
 		= F2Function<CouchdbSsmSessionStateGetQueryDTO, CouchdbSsmSessionStateGetQueryResultDTO>
 
-@Serializable
 @JsExport
 @JsName("CouchdbSsmSessionStateGetQueryDTO")
 interface CouchdbSsmSessionStateGetQueryDTO : Query {
@@ -31,7 +30,6 @@ interface CouchdbSsmSessionStateGetQueryDTO : Query {
 	val sessionName: SessionName
 }
 
-@Serializable
 @JsExport
 @JsName("CouchdbSsmSessionStateGetQueryResultDTO")
 interface CouchdbSsmSessionStateGetQueryResultDTO : Event {

--- a/c2-ssm/ssm-couchdb/ssm-couchdb-dsl/src/commonMain/kotlin/ssm/couchdb/dsl/query/CouchdbSsmSessionStateListQuery.kt
+++ b/c2-ssm/ssm-couchdb/ssm-couchdb-dsl/src/commonMain/kotlin/ssm/couchdb/dsl/query/CouchdbSsmSessionStateListQuery.kt
@@ -22,7 +22,6 @@ import ssm.chaincode.dsl.model.uri.ChaincodeUriDTO
 typealias CouchdbSsmSessionStateListQueryFunction
 		= F2Function<CouchdbSsmSessionStateListQueryDTO, CouchdbSsmSessionStateListQueryResultDTO>
 
-@Serializable
 @JsExport
 @JsName("CouchdbSsmSessionStateListQueryDTO")
 interface CouchdbSsmSessionStateListQueryDTO : PageQueryDTO {
@@ -36,7 +35,6 @@ interface CouchdbSsmSessionStateListQueryDTO : PageQueryDTO {
 	val ssm: SsmName?
 }
 
-@Serializable
 @JsExport
 @JsName("CouchdbSsmSessionStateListQueryResultDTO")
 interface CouchdbSsmSessionStateListQueryResultDTO : PageQueryResultDTO<SsmSessionStateDTO> {

--- a/c2-ssm/ssm-couchdb/ssm-couchdb-dsl/src/commonMain/kotlin/ssm/couchdb/dsl/query/CouchdbUserListQuery.kt
+++ b/c2-ssm/ssm-couchdb/ssm-couchdb-dsl/src/commonMain/kotlin/ssm/couchdb/dsl/query/CouchdbUserListQuery.kt
@@ -25,7 +25,6 @@ typealias CouchdbUserListQueryFunction = F2Function<CouchdbUserListQueryDTO, Cou
  * @parent [CouchdbUserListQueryFunction]
  */
 
-@Serializable
 @JsExport
 @JsName("CouchdbUserListQueryDTO")
 interface CouchdbUserListQueryDTO : Query {
@@ -40,7 +39,6 @@ interface CouchdbUserListQueryDTO : Query {
  * @title Get all admins: Result
  * @parent [CouchdbUserListQueryFunction]
  */
-@Serializable
 @JsExport
 @JsName("CouchdbUserListQueryResultDTO")
 interface CouchdbUserListQueryResultDTO : Event {

--- a/c2-ssm/ssm-data/ssm-data-dsl/src/commonMain/kotlin/ssm/data/dsl/features/query/DataChaincodeListQuery.kt
+++ b/c2-ssm/ssm-data/ssm-data-dsl/src/commonMain/kotlin/ssm/data/dsl/features/query/DataChaincodeListQuery.kt
@@ -15,7 +15,6 @@ import ssm.chaincode.dsl.model.uri.ChaincodeUri
  */
 typealias DataChaincodeListQueryFunction = F2Function<DataChaincodeListQuery, DataChaincodeListQueryResult>
 
-@Serializable
 @JsExport
 @JsName("DataChaincodeListQueryDTO")
 interface DataChaincodeListQueryDTO
@@ -30,7 +29,6 @@ interface DataChaincodeListQueryDTO
 @JsName("DataChaincodeListQuery")
 class DataChaincodeListQuery : DataChaincodeListQueryDTO
 
-@Serializable
 @JsExport
 @JsName("DataChaincodeListQueryResultDTO")
 interface DataChaincodeListQueryResultDTO {

--- a/c2-ssm/ssm-data/ssm-data-dsl/src/commonMain/kotlin/ssm/data/dsl/features/query/DataQueryDTO.kt
+++ b/c2-ssm/ssm-data/ssm-data-dsl/src/commonMain/kotlin/ssm/data/dsl/features/query/DataQueryDTO.kt
@@ -5,7 +5,6 @@ import kotlin.js.JsName
 import kotlinx.serialization.Serializable
 import ssm.chaincode.dsl.model.uri.SsmUriDTO
 
-@Serializable
 @JsExport
 @JsName("DataQueryDTO")
 interface DataQueryDTO {

--- a/c2-ssm/ssm-data/ssm-data-dsl/src/commonMain/kotlin/ssm/data/dsl/features/query/DataSsmGetQuery.kt
+++ b/c2-ssm/ssm-data/ssm-data-dsl/src/commonMain/kotlin/ssm/data/dsl/features/query/DataSsmGetQuery.kt
@@ -17,7 +17,6 @@ import ssm.data.dsl.model.DataSsm
  */
 typealias DataSsmGetQueryFunction = F2Function<DataSsmGetQueryDTO, DataSsmGetQueryResultDTO>
 
-@Serializable
 @JsExport
 @JsName("DataSsmGetQueryDTO")
 interface DataSsmGetQueryDTO : DataQueryDTO {
@@ -36,7 +35,6 @@ class DataSsmGetQuery(
 	override val ssmUri: SsmUri,
 ) : DataSsmGetQueryDTO
 
-@Serializable
 @JsExport
 @JsName("DataSsmGetQueryResultDTO")
 interface DataSsmGetQueryResultDTO {

--- a/c2-ssm/ssm-data/ssm-data-dsl/src/commonMain/kotlin/ssm/data/dsl/features/query/DataSsmListQuery.kt
+++ b/c2-ssm/ssm-data/ssm-data-dsl/src/commonMain/kotlin/ssm/data/dsl/features/query/DataSsmListQuery.kt
@@ -17,7 +17,6 @@ import ssm.data.dsl.model.DataSsmDTO
  */
 typealias DataSsmListQueryFunction = F2Function<DataSsmListQuery, DataSsmListQueryResult>
 
-@Serializable
 @JsExport
 @JsName("DataSsmListQueryDTO")
 interface DataSsmListQueryDTO
@@ -34,7 +33,6 @@ class DataSsmListQuery(
 	val chaincodes: List<ChaincodeUri>
 ) : DataSsmListQueryDTO
 
-@Serializable
 @JsExport
 @JsName("DataSsmListQueryResultDTO")
 interface DataSsmListQueryResultDTO {

--- a/c2-ssm/ssm-data/ssm-data-dsl/src/commonMain/kotlin/ssm/data/dsl/features/query/DataSsmSessionGetQuery.kt
+++ b/c2-ssm/ssm-data/ssm-data-dsl/src/commonMain/kotlin/ssm/data/dsl/features/query/DataSsmSessionGetQuery.kt
@@ -20,7 +20,6 @@ import ssm.data.dsl.model.DataSsmSessionDTO
  */
 typealias DataSsmSessionGetQueryFunction = F2Function<DataSsmSessionGetQueryDTO, DataSsmSessionGetQueryResultDTO>
 
-@Serializable
 @JsExport
 @JsName("DataSsmSessionGetQueryDTO")
 interface DataSsmSessionGetQueryDTO : DataQueryDTO {
@@ -45,7 +44,6 @@ class DataSsmSessionGetQuery(
 	override val ssmUri: SsmUri,
 ) : DataSsmSessionGetQueryDTO
 
-@Serializable
 @JsExport
 @JsName("DataSsmSessionGetQueryResultDTO")
 interface DataSsmSessionGetQueryResultDTO: Event {

--- a/c2-ssm/ssm-data/ssm-data-dsl/src/commonMain/kotlin/ssm/data/dsl/features/query/DataSsmSessionListQuery.kt
+++ b/c2-ssm/ssm-data/ssm-data-dsl/src/commonMain/kotlin/ssm/data/dsl/features/query/DataSsmSessionListQuery.kt
@@ -17,7 +17,6 @@ import ssm.data.dsl.model.DataSsmSessionDTO
  */
 typealias DataSsmSessionListQueryFunction = F2Function<DataSsmSessionListQueryDTO, DataSsmSessionListQueryResultDTO>
 
-@Serializable
 @JsExport
 @JsName("DataSsmSessionListQueryDTO")
 interface DataSsmSessionListQueryDTO : DataQueryDTO
@@ -34,7 +33,6 @@ class DataSsmSessionListQuery(
 	override val ssmUri: SsmUri,
 ) : DataSsmSessionListQueryDTO
 
-@Serializable
 @JsExport
 @JsName("DataSsmSessionListQueryResultDTO")
 interface DataSsmSessionListQueryResultDTO {

--- a/c2-ssm/ssm-data/ssm-data-dsl/src/commonMain/kotlin/ssm/data/dsl/features/query/DataSsmSessionLogGetQuery.kt
+++ b/c2-ssm/ssm-data/ssm-data-dsl/src/commonMain/kotlin/ssm/data/dsl/features/query/DataSsmSessionLogGetQuery.kt
@@ -21,7 +21,6 @@ import ssm.data.dsl.model.DataSsmSessionStateDTO
 typealias DataSsmSessionLogGetQueryFunction
 		= F2Function<DataSsmSessionLogGetQueryDTO, DataSsmSessionLogGetQueryResultDTO>
 
-@Serializable
 @JsExport
 @JsName("DataSsmSessionLogGetQueryDTO")
 interface DataSsmSessionLogGetQueryDTO : DataQueryDTO {
@@ -53,7 +52,6 @@ class DataSsmSessionLogGetQuery(
 	override val ssmUri: SsmUri,
 ) : DataSsmSessionLogGetQueryDTO
 
-@Serializable
 @JsExport
 @JsName("DataSsmSessionLogGetQueryResultDTO")
 interface DataSsmSessionLogGetQueryResultDTO {

--- a/c2-ssm/ssm-data/ssm-data-dsl/src/commonMain/kotlin/ssm/data/dsl/features/query/DataSsmSessionLogListQuery.kt
+++ b/c2-ssm/ssm-data/ssm-data-dsl/src/commonMain/kotlin/ssm/data/dsl/features/query/DataSsmSessionLogListQuery.kt
@@ -19,7 +19,6 @@ import ssm.data.dsl.model.DataSsmSessionState
 typealias DataSsmSessionLogListQueryFunction
 		= F2Function<DataSsmSessionLogListQueryDTO, DataSsmSessionLogListQueryResultDTO>
 
-@Serializable
 @JsExport
 @JsName("DataSsmSessionLogListQueryDTO")
 interface DataSsmSessionLogListQueryDTO : DataQueryDTO {
@@ -44,7 +43,6 @@ class DataSsmSessionLogListQuery(
 	override val ssmUri: SsmUri,
 ) : DataSsmSessionLogListQueryDTO
 
-@Serializable
 @JsExport
 @JsName("DataSsmSessionLogListQueryResultDTO")
 interface DataSsmSessionLogListQueryResultDTO {

--- a/c2-ssm/ssm-data/ssm-data-dsl/src/commonMain/kotlin/ssm/data/dsl/model/DataChannel.kt
+++ b/c2-ssm/ssm-data/ssm-data-dsl/src/commonMain/kotlin/ssm/data/dsl/model/DataChannel.kt
@@ -5,7 +5,6 @@ import kotlin.js.JsName
 import kotlinx.serialization.Serializable
 import ssm.chaincode.dsl.model.ChannelId
 
-@Serializable
 @JsExport
 @JsName("DataChannelDTO")
 interface DataChannelDTO {

--- a/c2-ssm/ssm-data/ssm-data-dsl/src/commonMain/kotlin/ssm/data/dsl/model/DataSsm.kt
+++ b/c2-ssm/ssm-data/ssm-data-dsl/src/commonMain/kotlin/ssm/data/dsl/model/DataSsm.kt
@@ -9,7 +9,6 @@ import ssm.chaincode.dsl.model.uri.SsmUri
 import ssm.chaincode.dsl.model.uri.SsmUriDTO
 import ssm.chaincode.dsl.model.uri.SsmVersion
 
-@Serializable
 @JsExport
 @JsName("DataSsmDTO")
 interface DataSsmDTO {

--- a/c2-ssm/ssm-data/ssm-data-dsl/src/commonMain/kotlin/ssm/data/dsl/model/DataSsmSession.kt
+++ b/c2-ssm/ssm-data/ssm-data-dsl/src/commonMain/kotlin/ssm/data/dsl/model/DataSsmSession.kt
@@ -8,7 +8,6 @@ import ssm.chaincode.dsl.blockchain.TransactionDTO
 import ssm.chaincode.dsl.model.SessionName
 import ssm.chaincode.dsl.model.uri.SsmUri
 
-@Serializable
 @JsExport
 @JsName("DataSsmSessionDTO")
 interface DataSsmSessionDTO {

--- a/c2-ssm/ssm-data/ssm-data-dsl/src/commonMain/kotlin/ssm/data/dsl/model/DataSsmSessionState.kt
+++ b/c2-ssm/ssm-data/ssm-data-dsl/src/commonMain/kotlin/ssm/data/dsl/model/DataSsmSessionState.kt
@@ -8,7 +8,6 @@ import ssm.chaincode.dsl.blockchain.TransactionDTO
 import ssm.chaincode.dsl.model.SsmSessionState
 import ssm.chaincode.dsl.model.SsmSessionStateDTO
 
-@Serializable
 @JsExport
 @JsName("DataSsmSessionStateDTO")
 interface DataSsmSessionStateDTO {

--- a/c2-ssm/ssm-data/ssm-data-dsl/src/commonMain/kotlin/ssm/data/dsl/model/DataSsmUser.kt
+++ b/c2-ssm/ssm-data/ssm-data-dsl/src/commonMain/kotlin/ssm/data/dsl/model/DataSsmUser.kt
@@ -6,7 +6,6 @@ import kotlinx.serialization.Serializable
 import ssm.chaincode.dsl.model.Agent
 import ssm.chaincode.dsl.model.AgentDTO
 
-@Serializable
 @JsExport
 @JsName("DataSsmUserDTO")
 interface DataSsmUserDTO {


### PR DESCRIPTION
Removed unnecessary @Serializable annotations from DTO interfaces across various modules to simplify the code and avoid confusion.
Added Kotlin serialization plugin to the build scripts for better handling of JSON and serialization tasks in ssm-chaincode-dsl, ssm-couchdb-dsl, and ssm-data-dsl modules.