### PR TITLE
Refactor Session Logs Query with Concurrent Flattening

### DIFF
--- a/c2-ssm/ssm-chaincode/ssm-chaincode-f2/src/main/kotlin/ssm/chaincode/f2/query/SsmGetSessionLogsQueryFunctionImpl.kt
+++ b/c2-ssm/ssm-chaincode/ssm-chaincode-f2/src/main/kotlin/ssm/chaincode/f2/query/SsmGetSessionLogsQueryFunctionImpl.kt
@@ -1,11 +1,12 @@
 package ssm.chaincode.f2.query
 
+import f2.dsl.fnc.operators.flattenConcurrently
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.map
 import ssm.chaincode.dsl.config.InvokeChunkedProps
 import ssm.chaincode.dsl.config.chunk
+import ssm.chaincode.dsl.model.SsmName
 import ssm.chaincode.dsl.query.SsmGetSessionLogsQuery
 import ssm.chaincode.dsl.query.SsmGetSessionLogsQueryFunction
 import ssm.chaincode.dsl.query.SsmGetSessionLogsQueryResult
@@ -17,21 +18,33 @@ class SsmGetSessionLogsQueryFunctionImpl(
 	private val props: InvokeChunkedProps
 ): SsmGetSessionLogsQueryFunction  {
 
-	// TODO CHANGE THAT should better use flow
 	override suspend fun invoke(
 		msgs: Flow<SsmGetSessionLogsQuery>
 	): Flow<SsmGetSessionLogsQueryResult> = msgs.map { payload ->
-		GetLogQuery(
-			chaincodeUri = payload.chaincodeUri,
-			sessionName = payload.sessionName
+		GetLogQueryWithSsmName(
+			ssmName = payload.ssmName,
+			getLogQuery = GetLogQuery(
+				chaincodeUri = payload.chaincodeUri,
+				sessionName = payload.sessionName
+			)
 		)
-	}.chunk(props).map { queries -> queryService.getLogs(queries)}.flatMapConcat { logs ->
-		logs.associateBy { it.first().state }.map { (state, logs) ->
+	}.chunk(props).map { queries ->
+		val logsResult = queryService.getLogs(queries.map { it.getLogQuery })
+		val logBySessionName = logsResult.associateBy { log ->
+			log.firstOrNull()?.state?.session
+		}
+		queries.map { query ->
+			val logs = logBySessionName[query.getLogQuery.sessionName] ?: emptyList()
 			SsmGetSessionLogsQueryResult(
-				ssmName = state.ssm!!,
-				sessionName = state.session,
+				ssmName = query.ssmName,
+				sessionName = query.getLogQuery.sessionName,
 				logs = logs
 			)
 		}.asFlow()
-	}
+	}.flattenConcurrently()
 }
+
+class GetLogQueryWithSsmName(
+	val ssmName: SsmName,
+	val getLogQuery: GetLogQuery,
+)


### PR DESCRIPTION
- Improved session logs query performance and readability by introducing `flattenConcurrently` for enhanced concurrency handling.
- Added a new data class `GetLogQueryWithSsmName` to encapsulate `ssmName` for better separation of concerns and maintainability.