### PR TITLE
Refactor: Rename `SsmChaincodeConfig` to `SsmChaincodeProperties` and Introduce `BatchPropertiesDTO`

### DIFF
--- a/c2-ssm/ssm-bdd/ssm-bdd-config/src/main/kotlin/ssm/bdd/config/SsmBddConfig.kt
+++ b/c2-ssm/ssm-bdd/ssm-bdd-config/src/main/kotlin/ssm/bdd/config/SsmBddConfig.kt
@@ -1,7 +1,7 @@
 package ssm.bdd.config
 
 import ssm.chaincode.dsl.config.BatchProperties
-import ssm.chaincode.dsl.config.SsmChaincodeConfig
+import ssm.chaincode.dsl.config.SsmChaincodeProperties
 import ssm.chaincode.dsl.model.uri.ChaincodeUri
 import ssm.couchdb.dsl.config.SsmCouchdbConfig
 import ssm.data.dsl.config.DataSsmConfig
@@ -74,9 +74,9 @@ object SsmBddConfig {
 						.orIfGitlab(Commune.Chaincode.chaincodeUri)
 				)
 			}
-		val config: SsmChaincodeConfig
+		val config: SsmChaincodeProperties
 			get() {
-				return SsmChaincodeConfig(batch = BatchProperties(), url = url)
+				return SsmChaincodeProperties(url = url)
 			}
 	}
 

--- a/c2-ssm/ssm-bdd/ssm-bdd-features/src/main/kotlin/ssm/bdd/config/SsmCommandStep.kt
+++ b/c2-ssm/ssm-bdd/ssm-bdd-features/src/main/kotlin/ssm/bdd/config/SsmCommandStep.kt
@@ -4,7 +4,7 @@ import io.cucumber.datatable.DataTable
 import io.cucumber.java8.En
 import io.cucumber.java8.Scenario
 import kotlinx.coroutines.runBlocking
-import ssm.chaincode.dsl.config.SsmChaincodeConfig
+import ssm.chaincode.dsl.config.SsmChaincodeProperties
 import ssm.chaincode.dsl.model.Agent
 import ssm.chaincode.dsl.model.AgentName
 import ssm.chaincode.dsl.model.SessionName
@@ -22,7 +22,7 @@ import ssm.sdk.sign.model.SignerUser
 abstract class SsmCommandStep {
 
 	lateinit var bag: SsmCucumberBag
-	lateinit var config: SsmChaincodeConfig
+	lateinit var config: SsmChaincodeProperties
 
 	@Suppress("LongMethod")
 	fun En.prepareSteps() {

--- a/c2-ssm/ssm-bdd/ssm-bdd-features/src/main/kotlin/ssm/bdd/config/SsmQueryStep.kt
+++ b/c2-ssm/ssm-bdd/ssm-bdd-features/src/main/kotlin/ssm/bdd/config/SsmQueryStep.kt
@@ -6,7 +6,7 @@ import io.cucumber.java8.Scenario
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions
 import ssm.chaincode.dsl.config.BatchProperties
-import ssm.chaincode.dsl.config.SsmChaincodeConfig
+import ssm.chaincode.dsl.config.SsmChaincodeProperties
 import ssm.chaincode.dsl.model.SessionName
 import ssm.chaincode.dsl.model.SsmAction
 import ssm.chaincode.dsl.model.SsmName
@@ -20,15 +20,15 @@ import ssm.chaincode.dsl.model.uri.toSsmUri
 abstract class SsmQueryStep {
 
 	lateinit var bag: SsmCucumberBag
-	lateinit var config: SsmChaincodeConfig
+	lateinit var config: SsmChaincodeProperties
+	var batch: BatchProperties = BatchProperties()
 
 	@Suppress("LongMethod")
 	fun En.prepareSteps() {
 		Before { scenario: Scenario ->
 			bag = SsmCucumberBag.init(scenario)
-			config = SsmChaincodeConfig(
+			config = SsmChaincodeProperties(
 				url = bag.config.baseUrl,
-				batch = BatchProperties()
 			)
 		}
 

--- a/c2-ssm/ssm-chaincode/ssm-chaincode-bdd/src/main/kotlin/ssm/chaincode/bdd/SsmChaincodeBddSteps.kt
+++ b/c2-ssm/ssm-chaincode/ssm-chaincode-bdd/src/main/kotlin/ssm/chaincode/bdd/SsmChaincodeBddSteps.kt
@@ -23,7 +23,7 @@ class SsmChaincodeBddSteps : SsmQueryStep(), En {
 	init {
 		prepareSteps()
 		Before { _: Scenario ->
-			ssmChaincodeQueryFunctions = ChaincodeSsmQueriesImpl(config)
+			ssmChaincodeQueryFunctions = ChaincodeSsmQueriesImpl(batch, config)
 		}
 
 	}

--- a/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/config/BatchProperties.kt
+++ b/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/config/BatchProperties.kt
@@ -7,10 +7,16 @@ import kotlin.js.JsExport
 import kotlinx.serialization.Serializable
 
 @JsExport
-@Serializable
-class BatchProperties {
-    val size: Int = BATCH_DEFAULT_SIZE
-    val concurrency: Int = BATCH_DEFAULT_CONCURRENCY
+interface BatchPropertiesDTO {
+    val size: Int
+    val concurrency: Int
 }
+
+@JsExport
+@Serializable
+class BatchProperties(
+    override val size: Int = BATCH_DEFAULT_SIZE,
+    override val concurrency: Int = BATCH_DEFAULT_CONCURRENCY
+):BatchPropertiesDTO
 
 fun BatchProperties.toBatch(): Batch = Batch(size, concurrency)

--- a/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/config/SsmChaincodePropertiesDTO.kt
+++ b/c2-ssm/ssm-chaincode/ssm-chaincode-dsl/src/commonMain/kotlin/ssm/chaincode/dsl/config/SsmChaincodePropertiesDTO.kt
@@ -18,13 +18,11 @@ interface SsmChaincodePropertiesDTO {
 	 * @example "http://peer.sandbox.Komune.io:9000"
 	 */
 	val url: String
-	val batch: BatchProperties
 }
 
 @Serializable
 @JsExport
 @JsName("ChaincodeSsmConfig")
-class SsmChaincodeConfig(
+class SsmChaincodeProperties(
 	override val url: String,
-	override val batch: BatchProperties = BatchProperties()
 ) : SsmChaincodePropertiesDTO

--- a/c2-ssm/ssm-chaincode/ssm-chaincode-f2/src/main/kotlin/ssm/chaincode/f2/ChaincodeSsmQueriesImpl.kt
+++ b/c2-ssm/ssm-chaincode/ssm-chaincode-f2/src/main/kotlin/ssm/chaincode/f2/ChaincodeSsmQueriesImpl.kt
@@ -1,7 +1,8 @@
 package ssm.chaincode.f2
 
 import ssm.chaincode.dsl.SsmChaincodeQueries
-import ssm.chaincode.dsl.config.SsmChaincodeConfig
+import ssm.chaincode.dsl.config.BatchProperties
+import ssm.chaincode.dsl.config.SsmChaincodeProperties
 import ssm.chaincode.dsl.query.SsmGetAdminFunction
 import ssm.chaincode.dsl.query.SsmGetQueryFunction
 import ssm.chaincode.dsl.query.SsmGetSessionLogsQueryFunction
@@ -27,9 +28,10 @@ import ssm.sdk.core.SsmSdkConfig
 import ssm.sdk.core.SsmServiceFactory
 
 class ChaincodeSsmQueriesImpl(
-    private val config: SsmChaincodeConfig,
-    private val ssmQueryService: SsmQueryService
-		= SsmServiceFactory.builder(SsmSdkConfig(config.url), config.batch).buildQueryService()
+	private val batchProperties: BatchProperties,
+	private val config: SsmChaincodeProperties,
+	private val ssmQueryService: SsmQueryService
+		= SsmServiceFactory.builder(SsmSdkConfig(config.url), batchProperties).buildQueryService()
 ): SsmChaincodeQueries {
 
 	override fun ssmGetAdminFunction(): SsmGetAdminFunction {
@@ -41,7 +43,7 @@ class ChaincodeSsmQueriesImpl(
 	}
 
 	override fun ssmGetSessionLogsQueryFunction(): SsmGetSessionLogsQueryFunction {
-		return SsmGetSessionLogsQueryFunctionImpl(config.batch, ssmQueryService)
+		return SsmGetSessionLogsQueryFunctionImpl(batchProperties, ssmQueryService)
 	}
 
 	override fun ssmGetSessionQueryFunction(): SsmGetSessionQueryFunction {

--- a/c2-ssm/ssm-data/ssm-data-bdd/src/main/kotlin/ssm/data/bdd/DataSteps.kt
+++ b/c2-ssm/ssm-data/ssm-data-bdd/src/main/kotlin/ssm/data/bdd/DataSteps.kt
@@ -27,7 +27,7 @@ class DataSteps : SsmQueryStep(), En {
 
 	val ssmDataConfig: DataSsmConfig = SsmBddConfig.Data.config
 	val dataSsmQueryFunctionImpl =
-		DataSsmQueryFunctionImpl(ssmDataConfig, ChaincodeSsmQueriesImpl(ssmDataConfig.chaincode))
+		DataSsmQueryFunctionImpl(ssmDataConfig, ChaincodeSsmQueriesImpl(batch, ssmDataConfig.chaincode))
 	val couchdbSsmQueriesFunctionImpl = CouchdbSsmQueriesFunctionImpl(ssmDataConfig.couchdb)
 
 	init {

--- a/c2-ssm/ssm-data/ssm-data-dsl/src/commonMain/kotlin/ssm/data/dsl/config/DataSsmConfig.kt
+++ b/c2-ssm/ssm-data/ssm-data-dsl/src/commonMain/kotlin/ssm/data/dsl/config/DataSsmConfig.kt
@@ -1,8 +1,7 @@
 package ssm.data.dsl.config
 
-import f2.dsl.fnc.operators.CHUNK_DEFAULT_SIZE
 import ssm.chaincode.dsl.config.BatchProperties
-import ssm.chaincode.dsl.config.SsmChaincodeConfig
+import ssm.chaincode.dsl.config.SsmChaincodeProperties
 import ssm.couchdb.dsl.config.SsmCouchdbConfig
 
 /**
@@ -22,6 +21,6 @@ data class DataSsmConfig(
 	/**
 	 *  Configuration for couchdb.
 	 */
-	val chaincode: SsmChaincodeConfig,
+	val chaincode: SsmChaincodeProperties,
 
 	)

--- a/c2-ssm/ssm-data/ssm-data-f2/src/main/kotlin/ssm/api/DataSsmQueryFunctionImpl.kt
+++ b/c2-ssm/ssm-data/ssm-data-f2/src/main/kotlin/ssm/api/DataSsmQueryFunctionImpl.kt
@@ -9,6 +9,7 @@ import ssm.api.features.query.DataSsmSessionLogGetQueryFunctionImpl
 import ssm.api.features.query.DataSsmSessionLogListQueryFunctionImpl
 import ssm.api.features.query.internal.DataSsmSessionConvertFunctionImpl
 import ssm.chaincode.dsl.SsmChaincodeQueries
+import ssm.chaincode.dsl.config.BatchProperties
 import ssm.chaincode.f2.ChaincodeSsmQueriesImpl
 import ssm.couchdb.dsl.SsmCouchDbQueries
 import ssm.couchdb.f2.CouchdbSsmQueriesFunctionImpl
@@ -24,7 +25,7 @@ import ssm.data.dsl.features.query.DataSsmSessionLogListQueryFunction
 
 class DataSsmQueryFunctionImpl(
 	private val config: DataSsmConfig,
-	private val ssmChaincodeQueries: SsmChaincodeQueries = ChaincodeSsmQueriesImpl(config.chaincode),
+	private val ssmChaincodeQueries: SsmChaincodeQueries = ChaincodeSsmQueriesImpl(config.batch, config.chaincode),
 	private val couchDbSsmQueries: SsmCouchDbQueries = CouchdbSsmQueriesFunctionImpl(config.couchdb)
 ) : SsmApiQueryFunctions {
 

--- a/c2-ssm/ssm-spring/ssm-chaincode-spring-boot-starter/src/main/kotlin/ssm/chaincode/spring/autoconfigure/SsmChaincodeAutoConfiguration.kt
+++ b/c2-ssm/ssm-spring/ssm-chaincode-spring-boot-starter/src/main/kotlin/ssm/chaincode/spring/autoconfigure/SsmChaincodeAutoConfiguration.kt
@@ -1,12 +1,14 @@
 package ssm.chaincode.spring.autoconfigure
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import ssm.chaincode.dsl.SsmChaincodeQueries
-import ssm.chaincode.dsl.config.SsmChaincodeConfig
+import ssm.chaincode.dsl.config.BatchProperties
+import ssm.chaincode.dsl.config.SsmChaincodeProperties
 import ssm.chaincode.dsl.query.SsmGetAdminFunction
 import ssm.chaincode.dsl.query.SsmGetQueryFunction
 import ssm.chaincode.dsl.query.SsmGetSessionLogsQueryFunction
@@ -20,19 +22,27 @@ import ssm.chaincode.dsl.query.SsmListUserQueryFunction
 import ssm.chaincode.f2.ChaincodeSsmQueriesImpl
 
 @ConditionalOnProperty(prefix = "ssm.chaincode", name = ["url"])
-@EnableConfigurationProperties(SsmChaincodeProperties::class)
+@EnableConfigurationProperties(SsmChaincodeConfiguration::class)
 @Configuration(proxyBeanMethods = false)
 class SsmChaincodeAutoConfiguration {
 
 	@Bean
-	fun ssmChaincodeConfig(
-		ssmChaincodeProperties: SsmChaincodeProperties
-	): SsmChaincodeConfig = ssmChaincodeProperties.chaincode
+	@ConditionalOnMissingBean(SsmChaincodeProperties::class)
+	fun ssmChaincodeProperties(
+		ssmChaincodeProperties: SsmChaincodeConfiguration
+	): SsmChaincodeProperties = ssmChaincodeProperties.chaincode
+
+	@Bean
+	@ConditionalOnMissingBean(BatchProperties::class)
+	fun batchProperties(
+		ssmChaincodeProperties: SsmChaincodeConfiguration
+	): BatchProperties = ssmChaincodeProperties.batch
 
 	@Bean
 	fun ssmChaincodeQueryFunctions(
-		ssmChaincodeConfig: SsmChaincodeConfig
-	): ChaincodeSsmQueriesImpl = ChaincodeSsmQueriesImpl(ssmChaincodeConfig)
+		ssmChaincodeProperties: SsmChaincodeProperties,
+		batchProperties: BatchProperties,
+	): ChaincodeSsmQueriesImpl = ChaincodeSsmQueriesImpl(batchProperties, ssmChaincodeProperties)
 }
 
 @ConditionalOnBean(ChaincodeSsmQueriesImpl::class)

--- a/c2-ssm/ssm-spring/ssm-chaincode-spring-boot-starter/src/main/kotlin/ssm/chaincode/spring/autoconfigure/SsmChaincodeAutoConfigurationBeanFactoryInitializationAotProcessor.kt
+++ b/c2-ssm/ssm-spring/ssm-chaincode-spring-boot-starter/src/main/kotlin/ssm/chaincode/spring/autoconfigure/SsmChaincodeAutoConfigurationBeanFactoryInitializationAotProcessor.kt
@@ -8,7 +8,7 @@ import org.springframework.beans.factory.aot.BeanFactoryInitializationAotProcess
 import org.springframework.beans.factory.aot.BeanFactoryInitializationCode
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
 import org.springframework.util.ReflectionUtils
-import ssm.chaincode.dsl.config.SsmChaincodeConfig
+import ssm.chaincode.dsl.config.SsmChaincodeProperties
 
 class SsmChaincodeAutoConfigurationBeanFactoryInitializationAotProcessor : BeanFactoryInitializationAotProcessor {
     override fun processAheadOfTime(bf: ConfigurableListableBeanFactory): BeanFactoryInitializationAotContribution {
@@ -17,13 +17,13 @@ class SsmChaincodeAutoConfigurationBeanFactoryInitializationAotProcessor : BeanF
             val hints = ctx.runtimeHints
             val method: Method = ReflectionUtils.findMethod(
                 SsmChaincodeAutoConfiguration::class.java,
-                SsmChaincodeAutoConfiguration::ssmChaincodeConfig.name,
+                SsmChaincodeAutoConfiguration::ssmChaincodeProperties.name,
                 SsmChaincodeProperties::class.java
             )!!
             hints.reflection().registerMethod(method, ExecutableMode.INVOKE)
 
             hints.reflection().registerType(SsmChaincodeProperties::class.java)
-            hints.reflection().registerType(SsmChaincodeConfig::class.java)
+            hints.reflection().registerType(SsmChaincodeProperties::class.java)
         }
     }
 }

--- a/c2-ssm/ssm-spring/ssm-chaincode-spring-boot-starter/src/main/kotlin/ssm/chaincode/spring/autoconfigure/SsmChaincodeConfiguration.kt
+++ b/c2-ssm/ssm-spring/ssm-chaincode-spring-boot-starter/src/main/kotlin/ssm/chaincode/spring/autoconfigure/SsmChaincodeConfiguration.kt
@@ -1,11 +1,11 @@
-package ssm.couchdb.spring.autoconfigure
+package ssm.chaincode.spring.autoconfigure
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 import ssm.chaincode.dsl.config.BatchProperties
-import ssm.couchdb.dsl.config.SsmCouchdbConfig
+import ssm.chaincode.dsl.config.SsmChaincodeProperties
 
 @ConfigurationProperties(prefix = "ssm")
-data class SsmCouchdbProperties(
-	val couchdb: SsmCouchdbConfig,
+data class SsmChaincodeConfiguration(
+	val chaincode: SsmChaincodeProperties,
 	val batch: BatchProperties = BatchProperties()
 )

--- a/c2-ssm/ssm-spring/ssm-chaincode-spring-boot-starter/src/main/kotlin/ssm/chaincode/spring/autoconfigure/SsmChaincodeProperties.kt
+++ b/c2-ssm/ssm-spring/ssm-chaincode-spring-boot-starter/src/main/kotlin/ssm/chaincode/spring/autoconfigure/SsmChaincodeProperties.kt
@@ -1,9 +1,0 @@
-package ssm.chaincode.spring.autoconfigure
-
-import org.springframework.boot.context.properties.ConfigurationProperties
-import ssm.chaincode.dsl.config.SsmChaincodeConfig
-
-@ConfigurationProperties(prefix = "ssm")
-data class SsmChaincodeProperties(
-	val chaincode: SsmChaincodeConfig
-)

--- a/c2-ssm/ssm-spring/ssm-chaincode-spring-boot-starter/src/test/kotlin/ssm/chaincode/spring/autoconfigure/SsmChaincodeApplicationContextRunnerTest.kt
+++ b/c2-ssm/ssm-spring/ssm-chaincode-spring-boot-starter/src/test/kotlin/ssm/chaincode/spring/autoconfigure/SsmChaincodeApplicationContextRunnerTest.kt
@@ -14,7 +14,7 @@ class SsmChaincodeApplicationContextRunnerTest {
 		ApplicationContextRunnerBuilder()
 			.buildContext(SsmChaincodeConfigTest.localDockerComposeParams).run { context ->
 				assertThat(context).hasSingleBean(FunctionCatalog::class.java)
-				assertThat(context).hasSingleBean(SsmChaincodeProperties::class.java)
+				assertThat(context).hasSingleBean(SsmChaincodeConfiguration::class.java)
 				assertThat(context).hasBean(SsmChaincodeF2AutoConfiguration::ssmGetAdminFunction.name)
 				assertThat(context).hasBean(SsmChaincodeF2AutoConfiguration::ssmGetSessionLogsQueryFunction.name)
 				assertThat(context).hasBean(SsmChaincodeF2AutoConfiguration::ssmGetSessionLogsQueryFunction.name)
@@ -34,7 +34,7 @@ class SsmChaincodeApplicationContextRunnerTest {
 			types = arrayOf(ApplicationContextBuilder.SimpleConfiguration::class.java),
 			config = SsmChaincodeConfigTest.localDockerComposeParams
 		)
-		assertThat(context.getBean(SsmChaincodeAutoConfiguration::ssmChaincodeConfig.name)).isNotNull
+		assertThat(context.getBean(SsmChaincodeAutoConfiguration::ssmChaincodeProperties.name)).isNotNull
 		assertThat(context.getBean(FunctionCatalog::class.java)).isNotNull
 	}
 

--- a/c2-ssm/ssm-spring/ssm-data-spring-boot-starter/src/main/kotlin/ssm/data/spring/autoconfigure/SsmDataAutoConfiguration.kt
+++ b/c2-ssm/ssm-spring/ssm-data-spring-boot-starter/src/main/kotlin/ssm/data/spring/autoconfigure/SsmDataAutoConfiguration.kt
@@ -8,7 +8,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import ssm.api.DataSsmQueryFunctionImpl
-import ssm.chaincode.dsl.config.SsmChaincodeConfig
+import ssm.chaincode.dsl.config.SsmChaincodeProperties
 import ssm.couchdb.dsl.config.SsmCouchdbConfig
 import ssm.data.dsl.SsmApiQueryFunctions
 import ssm.data.dsl.config.DataSsmConfig
@@ -37,23 +37,23 @@ class DataSsmAutoConfiguration {
 		return dataSsmProperties.couchdb
 	}
 	@Bean
-	@ConditionalOnMissingBean(SsmChaincodeConfig::class)
+	@ConditionalOnMissingBean(SsmChaincodeProperties::class)
 	@ConditionalOnProperty(prefix = "ssm.chaincode", name = ["url"])
-	fun ssmChaincodeConfig(dataSsmProperties: SsmDataProperties): SsmChaincodeConfig? {
+	fun ssmChaincodeConfig(dataSsmProperties: SsmDataProperties): SsmChaincodeProperties? {
 		logger.debug("Configuration of ${DataSsmAutoConfiguration::ssmChaincodeConfig.name}...")
 		return dataSsmProperties.chaincode
 	}
 
 	@Bean
 	@ConditionalOnMissingBean(DataSsmConfig::class)
-	@ConditionalOnBean(value = [SsmCouchdbConfig::class, SsmChaincodeConfig::class])
+	@ConditionalOnBean(value = [SsmCouchdbConfig::class, SsmChaincodeProperties::class])
 	fun dataSsmConfig(
 		dataSsmProperties: SsmDataProperties,
 		ssmCouchdbConfig: SsmCouchdbConfig,
-		ssmChaincodeConfig: SsmChaincodeConfig
+		ssmChaincodeProperties: SsmChaincodeProperties
 	): DataSsmConfig {
 		logger.debug("Configuration of ${DataSsmAutoConfiguration::dataSsmConfig.name}...")
-		return DataSsmConfig(dataSsmProperties.batch, ssmCouchdbConfig, ssmChaincodeConfig)
+		return DataSsmConfig(dataSsmProperties.batch, ssmCouchdbConfig, ssmChaincodeProperties)
 	}
 
 	@Bean

--- a/c2-ssm/ssm-spring/ssm-data-spring-boot-starter/src/main/kotlin/ssm/data/spring/autoconfigure/SsmDataAutoConfigurationBeanFactoryInitializationAotProcessor.kt
+++ b/c2-ssm/ssm-spring/ssm-data-spring-boot-starter/src/main/kotlin/ssm/data/spring/autoconfigure/SsmDataAutoConfigurationBeanFactoryInitializationAotProcessor.kt
@@ -8,7 +8,7 @@ import org.springframework.beans.factory.aot.BeanFactoryInitializationAotProcess
 import org.springframework.beans.factory.aot.BeanFactoryInitializationCode
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
 import org.springframework.util.ReflectionUtils
-import ssm.chaincode.dsl.config.SsmChaincodeConfig
+import ssm.chaincode.dsl.config.SsmChaincodeProperties
 import ssm.couchdb.dsl.config.SsmCouchdbConfig
 
 class SsmDataAutoConfigurationBeanFactoryInitializationAotProcessor : BeanFactoryInitializationAotProcessor {
@@ -32,7 +32,7 @@ class SsmDataAutoConfigurationBeanFactoryInitializationAotProcessor : BeanFactor
 
             hints.reflection().registerType(SsmDataProperties::class.java)
             hints.reflection().registerType(SsmCouchdbConfig::class.java)
-            hints.reflection().registerType(SsmChaincodeConfig::class.java)
+            hints.reflection().registerType(SsmChaincodeProperties::class.java)
 
             SsmCouchdbConfig::class.java.declaredConstructors.forEach {
                 hints.reflection().registerConstructor(it, ExecutableMode.INVOKE)
@@ -40,7 +40,7 @@ class SsmDataAutoConfigurationBeanFactoryInitializationAotProcessor : BeanFactor
             SsmDataProperties::class.java.declaredConstructors.forEach {
                 hints.reflection().registerConstructor(it, ExecutableMode.INVOKE)
             }
-            SsmChaincodeConfig::class.java.declaredConstructors.forEach {
+            SsmChaincodeProperties::class.java.declaredConstructors.forEach {
                 hints.reflection().registerConstructor(it, ExecutableMode.INVOKE)
             }
 

--- a/c2-ssm/ssm-spring/ssm-data-spring-boot-starter/src/main/kotlin/ssm/data/spring/autoconfigure/SsmDataProperties.kt
+++ b/c2-ssm/ssm-spring/ssm-data-spring-boot-starter/src/main/kotlin/ssm/data/spring/autoconfigure/SsmDataProperties.kt
@@ -2,7 +2,7 @@ package ssm.data.spring.autoconfigure
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 import ssm.chaincode.dsl.config.BatchProperties
-import ssm.chaincode.dsl.config.SsmChaincodeConfig
+import ssm.chaincode.dsl.config.SsmChaincodeProperties
 import ssm.couchdb.dsl.config.SsmCouchdbConfig
 
 @ConfigurationProperties(prefix = "ssm")
@@ -14,7 +14,7 @@ data class SsmDataProperties(
 	/**
 	 *  Configuration for couchdb.
 	 */
-	val chaincode: SsmChaincodeConfig?,
+	val chaincode: SsmChaincodeProperties?,
 	/**
 	 * Configuration for chunking.
 	 */

--- a/c2-ssm/ssm-spring/ssm-tx-spring-boot-starter/ssm-tx-config-spring-boot-starter/src/main/kotlin/ssm/tx/config/spring/autoconfigure/SsmTxAutoConfigurationBeanFactoryInitializationAotProcessor.kt
+++ b/c2-ssm/ssm-spring/ssm-tx-spring-boot-starter/ssm-tx-config-spring-boot-starter/src/main/kotlin/ssm/tx/config/spring/autoconfigure/SsmTxAutoConfigurationBeanFactoryInitializationAotProcessor.kt
@@ -8,7 +8,7 @@ import org.springframework.beans.factory.aot.BeanFactoryInitializationAotProcess
 import org.springframework.beans.factory.aot.BeanFactoryInitializationCode
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
 import org.springframework.util.ReflectionUtils
-import ssm.chaincode.dsl.config.SsmChaincodeConfig
+import ssm.chaincode.dsl.config.SsmChaincodeProperties
 
 class SsmTxAutoConfigurationBeanFactoryInitializationAotProcessor : BeanFactoryInitializationAotProcessor {
     override fun processAheadOfTime(bf: ConfigurableListableBeanFactory): BeanFactoryInitializationAotContribution {
@@ -23,7 +23,7 @@ class SsmTxAutoConfigurationBeanFactoryInitializationAotProcessor : BeanFactoryI
             hints.reflection().registerMethod(method, ExecutableMode.INVOKE)
 
             hints.reflection().registerType(SsmTxProperties::class.java)
-            hints.reflection().registerType(SsmChaincodeConfig::class.java)
+            hints.reflection().registerType(SsmChaincodeProperties::class.java)
 
             SsmTxProperties.SignerAgentFileConfig::class.java.getDeclaredConstructors().forEach {
                 hints.reflection().registerConstructor(it, ExecutableMode.INVOKE)

--- a/c2-ssm/ssm-spring/ssm-tx-spring-boot-starter/ssm-tx-config-spring-boot-starter/src/main/kotlin/ssm/tx/config/spring/autoconfigure/SsmTxProperties.kt
+++ b/c2-ssm/ssm-spring/ssm-tx-spring-boot-starter/ssm-tx-config-spring-boot-starter/src/main/kotlin/ssm/tx/config/spring/autoconfigure/SsmTxProperties.kt
@@ -1,13 +1,15 @@
 package ssm.tx.config.spring.autoconfigure
 
 import org.springframework.boot.context.properties.ConfigurationProperties
-import ssm.chaincode.dsl.config.SsmChaincodeConfig
+import ssm.chaincode.dsl.config.BatchProperties
+import ssm.chaincode.dsl.config.SsmChaincodeProperties
 import ssm.sdk.sign.model.SignerAdmin
 
 @ConfigurationProperties(prefix = "ssm")
 data class SsmTxProperties(
-	val chaincode: SsmChaincodeConfig?,
+	val chaincode: SsmChaincodeProperties?,
 	val signer: SignerFileConfig?,
+	val batch: BatchProperties = BatchProperties()
 ) {
 	class SignerFileConfig(
 		val admin: SignerAgentFileConfig?,


### PR DESCRIPTION
- Renamed `SsmChaincodeConfig` to `SsmChaincodeProperties` to clarify its role as a properties holder.  
- Added `BatchPropertiesDTO` interface and refactored `BatchProperties` to implement it, improving flexibility and maintainability.  





