### PR TITLE
Simplify Chaincode Query Debug Logging

### DIFF
--- a/c2-chaincode/chaincode-api/chaincode-api-gateway/src/main/kotlin/io/komune/c2/chaincode/api/gateway/ChaincodeRestEndpoint.kt
+++ b/c2-chaincode/chaincode-api/chaincode-api-gateway/src/main/kotlin/io/komune/c2/chaincode/api/gateway/ChaincodeRestEndpoint.kt
@@ -40,7 +40,7 @@ class ChaincodeRestEndpoint(
 		fcn: String,
 		args: Array<String>
 	): CompletableFuture<String> {
-		logger.debug("Querying chaincode $chaincode on channel $channel with cmd $cmd, fcn $fcn and args ${args.joinToString()}")
+		logger.debug("Querying chaincode $cmd")
 		return chaincodeService.execute(InvokeParams(channel, chaincode, cmd, fcn, args))
 	}
 


### PR DESCRIPTION
- Reduce verbosity in debug logs by only displaying the executed command for chaincode queries.  
- Retain detailed parameters within the method call, maintaining necessary context while improving log readability.
