### PR TITLE
Improve build configuration consistency across Makefile and Gradle

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -37,7 +37,7 @@ jobs:
     with:
       with-docker-registry-login: 'true'
       make-file: 'make_docker.mk'
-      on-tag: 'publish promote'
+      on-tag: 'stage_promote'
       force-publish: 'true'
     secrets:
       PKG_GITHUB_USERNAME: ${{ github.actor }}
@@ -55,7 +55,7 @@ jobs:
       pages: write
       id-token: write
     with:
-      on-tag: 'publish_promote'
+      on-tag: 'stage_promote'
       make-file: 'make_docs.mk'
       with-chromatic: false
       storybook-dir: storybook

--- a/Makefile
+++ b/Makefile
@@ -4,23 +4,24 @@ VERSION = $(shell cat VERSION)
 
 ## New
 lint:
-	@make -f libs.mk lint
-	@make -f docker.mk lint
+	@make -f make_libs.mk lint
+	@make -f make_docker.mk lint
 
 build:
-	@make -f libs.mk build
-	@make -f docker.mk build
+	@make -f make_libs.mk build
+	@make -f make_docker.mk build
 
 test-pre:
-	@make -f libs.mk test-pre
+	@make -f make_libs.mk test-pre
 
 test:
-	@make -f libs.mk test
-	@make -f docker.mk test
+	@make -f make_libs.mk test
+	@make -f make_docker.mk test
 
-publish:
-	@make -f libs.mk publish
-	@make -f docker.mk publish
+stage:
+	@make -f make_libs.mk stage
+	@make -f make_docker.mk stage
+
 
 promote:
 	@make -f libs.mk promote

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 repositories {
 	mavenCentral()
-	maven { url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots") }
+	maven { url = uri("https://central.sonatype.com/repository/maven-snapshots") }
 	mavenLocal()
 }
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,8 +1,8 @@
-import io.komune.gradle.dependencies.FixersDependencies
-import io.komune.gradle.dependencies.FixersPluginVersions
-import io.komune.gradle.dependencies.FixersVersions
-import io.komune.gradle.dependencies.Scope
-import io.komune.gradle.dependencies.add
+import io.komune.fixers.gradle.dependencies.FixersDependencies
+import io.komune.fixers.gradle.dependencies.FixersPluginVersions
+import io.komune.fixers.gradle.dependencies.FixersVersions
+import io.komune.fixers.gradle.dependencies.Scope
+import io.komune.fixers.gradle.dependencies.add
 import java.net.URI
 import org.gradle.api.artifacts.dsl.RepositoryHandler
 
@@ -40,7 +40,7 @@ object Versions {
 
 fun RepositoryHandler.defaultRepo() {
 	mavenCentral()
-	maven { url = URI("https://s01.oss.sonatype.org/content/repositories/snapshots") }
+	maven { url = URI("https://central.sonatype.com/repository/maven-snapshots") }
 	maven { url = URI("https://repo.spring.io/milestone") }
 	mavenLocal()
 }
@@ -77,6 +77,8 @@ object Dependencies {
 		"org.junit.jupiter:junit-jupiter-api:${Versions.junit}",
 		"org.assertj:assertj-core:${Versions.assertj}"
 	)
+
+	fun cucumber(scope: Scope) = FixersDependencies.Jvm.Test.cucumber(scope)
 
 	fun fabricSdk(scope: Scope) = scope.add(
 		"org.hyperledger.fabric-sdk-java:fabric-sdk-java:${Versions.fabric}"

--- a/c2-chaincode/Makefile
+++ b/c2-chaincode/Makefile
@@ -12,11 +12,7 @@ build:
 	make build -C chaincode-ex02
 	make build -C chaincode-ssm
 
-publish:
-	make push -C chaincode-ex02
-	make push -C chaincode-ssm
-
-promote:
+push:
 	make push -C chaincode-ex02
 	make push -C chaincode-ssm
 

--- a/c2-sandbox/Makefile
+++ b/c2-sandbox/Makefile
@@ -18,14 +18,7 @@ build:
 	make build -e VERSION=${VERSION} -e DOCKER_REPOSITORY=${DOCKER_REPOSITORY} -C c2-sandbox-peer
 	make build -e VERSION=${VERSION} -e DOCKER_REPOSITORY=${DOCKER_REPOSITORY} -C c2-sandbox-ssm-gateway
 
-publish:
-	make push -e VERSION=${VERSION} -e DOCKER_REPOSITORY=${DOCKER_REPOSITORY} -C c2-sandbox-ca
-	make push -e VERSION=${VERSION} -e DOCKER_REPOSITORY=${DOCKER_REPOSITORY} -C c2-sandbox-cli
-	make push -e VERSION=${VERSION} -e DOCKER_REPOSITORY=${DOCKER_REPOSITORY} -C c2-sandbox-orderer
-	make push -e VERSION=${VERSION} -e DOCKER_REPOSITORY=${DOCKER_REPOSITORY} -C c2-sandbox-peer
-	make push -e VERSION=${VERSION} -e DOCKER_REPOSITORY=${DOCKER_REPOSITORY} -C c2-sandbox-ssm-gateway
-
-promote:
+push:
 	make push -e VERSION=${VERSION} -e DOCKER_REPOSITORY=${DOCKER_REPOSITORY} -C c2-sandbox-ca
 	make push -e VERSION=${VERSION} -e DOCKER_REPOSITORY=${DOCKER_REPOSITORY} -C c2-sandbox-cli
 	make push -e VERSION=${VERSION} -e DOCKER_REPOSITORY=${DOCKER_REPOSITORY} -C c2-sandbox-orderer

--- a/c2-ssm/ssm-bdd/ssm-bdd-config/build.gradle.kts
+++ b/c2-ssm/ssm-bdd/ssm-bdd-config/build.gradle.kts
@@ -1,5 +1,5 @@
-import io.komune.gradle.dependencies.FixersDependencies
-import io.komune.gradle.dependencies.FixersVersions
+import io.komune.fixers.gradle.dependencies.FixersDependencies
+import io.komune.fixers.gradle.dependencies.FixersVersions
 
 plugins {
 	id("io.komune.fixers.gradle.kotlin.jvm")

--- a/c2-ssm/ssm-bdd/ssm-bdd-features/build.gradle.kts
+++ b/c2-ssm/ssm-bdd/ssm-bdd-features/build.gradle.kts
@@ -5,6 +5,5 @@ plugins {
 dependencies {
 	api(project(":c2-ssm:ssm-sdk:ssm-sdk-core"))
 	api(project(":c2-ssm:ssm-bdd:ssm-bdd-config"))
-
-	io.komune.gradle.dependencies.FixersDependencies.Jvm.Test.junit(::api)
+	Dependencies.test(::api)
 }

--- a/c2-ssm/ssm-chaincode/ssm-chaincode-bdd/build.gradle.kts
+++ b/c2-ssm/ssm-chaincode/ssm-chaincode-bdd/build.gradle.kts
@@ -1,5 +1,3 @@
-import io.komune.gradle.dependencies.FixersDependencies
-
 plugins {
 	id("io.komune.fixers.gradle.kotlin.jvm")
 }
@@ -7,5 +5,5 @@ plugins {
 dependencies {
 	api(project(":c2-ssm:ssm-chaincode:ssm-chaincode-f2"))
 	api(project(":c2-ssm:ssm-sdk:ssm-sdk-bdd"))
-	FixersDependencies.Jvm.Test.cucumber(::api)
+	Dependencies.cucumber(::api)
 }

--- a/c2-ssm/ssm-sdk/ssm-sdk-bdd/build.gradle.kts
+++ b/c2-ssm/ssm-sdk/ssm-sdk-bdd/build.gradle.kts
@@ -1,5 +1,3 @@
-import io.komune.gradle.dependencies.FixersDependencies
-
 plugins {
 	id("io.komune.fixers.gradle.kotlin.jvm")
 }
@@ -12,5 +10,5 @@ dependencies {
 	api(project(":c2-ssm:ssm-sdk:ssm-sdk-core"))
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin:${Versions.jacksonKotlin}")
 
-	FixersDependencies.Jvm.Test.cucumber(::api)
+	Dependencies.cucumber(::api)
 }

--- a/c2-ssm/ssm-spring/ssm-chaincode-spring-boot-starter/build.gradle.kts
+++ b/c2-ssm/ssm-spring/ssm-chaincode-spring-boot-starter/build.gradle.kts
@@ -1,5 +1,3 @@
-import io.komune.gradle.dependencies.FixersVersions
-
 plugins {
 	id("io.komune.fixers.gradle.kotlin.jvm")
 	id("io.komune.fixers.gradle.publish")
@@ -12,7 +10,7 @@ dependencies {
 
 	api("io.komune.f2:f2-spring-boot-starter-function:${Versions.f2}")
 
-	kapt("org.springframework.boot:spring-boot-configuration-processor:${FixersVersions.Spring.boot}")
+	kapt("org.springframework.boot:spring-boot-configuration-processor:${Versions.springBoot}")
 
 	testImplementation(project(":c2-ssm:ssm-bdd:ssm-bdd-spring-autoconfigure"))
 }

--- a/c2-ssm/ssm-spring/ssm-couchdb-spring-boot-starter/build.gradle.kts
+++ b/c2-ssm/ssm-spring/ssm-couchdb-spring-boot-starter/build.gradle.kts
@@ -1,5 +1,3 @@
-import io.komune.gradle.dependencies.FixersVersions
-
 plugins {
 	id("io.komune.fixers.gradle.kotlin.jvm")
 	id("io.komune.fixers.gradle.publish")
@@ -12,7 +10,7 @@ dependencies {
 
 	api("io.komune.f2:f2-spring-boot-starter-function:${Versions.f2}")
 
-	kapt("org.springframework.boot:spring-boot-configuration-processor:${FixersVersions.Spring.boot}")
+	kapt("org.springframework.boot:spring-boot-configuration-processor:${Versions.springBoot}")
 
 	testImplementation(project(":c2-ssm:ssm-bdd:ssm-bdd-spring-autoconfigure"))
 }

--- a/c2-ssm/ssm-spring/ssm-data-spring-boot-starter/build.gradle.kts
+++ b/c2-ssm/ssm-spring/ssm-data-spring-boot-starter/build.gradle.kts
@@ -1,5 +1,3 @@
-import io.komune.gradle.dependencies.FixersVersions
-
 plugins {
 	id("io.komune.fixers.gradle.kotlin.jvm")
 	id("io.komune.fixers.gradle.publish")
@@ -12,7 +10,7 @@ dependencies {
 	api(project(":c2-ssm:ssm-data:ssm-data-sync"))
 
 	api("io.komune.f2:f2-spring-boot-starter-function:${Versions.f2}")
-	kapt("org.springframework.boot:spring-boot-configuration-processor:${FixersVersions.Spring.boot}")
+	kapt("org.springframework.boot:spring-boot-configuration-processor:${Versions.springBoot}")
 
 	Dependencies.slf4j(::implementation)
 

--- a/c2-ssm/ssm-spring/ssm-tx-spring-boot-starter/ssm-tx-config-spring-boot-starter/build.gradle.kts
+++ b/c2-ssm/ssm-spring/ssm-tx-spring-boot-starter/ssm-tx-config-spring-boot-starter/build.gradle.kts
@@ -1,5 +1,3 @@
-import io.komune.gradle.dependencies.FixersVersions
-
 plugins {
 	id("io.komune.fixers.gradle.kotlin.jvm")
 	id("io.komune.fixers.gradle.publish")
@@ -12,7 +10,7 @@ dependencies {
 
 	api("io.komune.f2:f2-spring-boot-starter-function:${Versions.f2}")
 
-	kapt("org.springframework.boot:spring-boot-configuration-processor:${FixersVersions.Spring.boot}")
+	kapt("org.springframework.boot:spring-boot-configuration-processor:${Versions.springBoot}")
 
 	testImplementation(project(":c2-ssm:ssm-bdd:ssm-bdd-spring-autoconfigure"))
 }

--- a/c2-ssm/ssm-spring/ssm-tx-spring-boot-starter/ssm-tx-create-ssm-spring-boot-starter/build.gradle.kts
+++ b/c2-ssm/ssm-spring/ssm-tx-spring-boot-starter/ssm-tx-create-ssm-spring-boot-starter/build.gradle.kts
@@ -1,5 +1,3 @@
-import io.komune.gradle.dependencies.FixersVersions
-
 plugins {
 	id("io.komune.fixers.gradle.kotlin.jvm")
 	id("io.komune.fixers.gradle.publish")
@@ -12,7 +10,7 @@ dependencies {
 	api(project(":c2-ssm:ssm-spring:ssm-tx-spring-boot-starter:ssm-tx-config-spring-boot-starter"))
 	api("io.komune.f2:f2-spring-boot-starter-function:${Versions.f2}")
 
-	kapt("org.springframework.boot:spring-boot-configuration-processor:${FixersVersions.Spring.boot}")
+	kapt("org.springframework.boot:spring-boot-configuration-processor:${Versions.springBoot}")
 
 	testImplementation(project(":c2-ssm:ssm-bdd:ssm-bdd-spring-autoconfigure"))
 }

--- a/c2-ssm/ssm-spring/ssm-tx-spring-boot-starter/ssm-tx-init-ssm-spring-boot-starter/build.gradle.kts
+++ b/c2-ssm/ssm-spring/ssm-tx-spring-boot-starter/ssm-tx-init-ssm-spring-boot-starter/build.gradle.kts
@@ -1,5 +1,3 @@
-import io.komune.gradle.dependencies.FixersVersions
-
 plugins {
 	id("io.komune.fixers.gradle.kotlin.jvm")
 	id("io.komune.fixers.gradle.publish")
@@ -11,7 +9,7 @@ dependencies {
 	api(project(":c2-ssm:ssm-tx:ssm-tx-f2"))
 	api(project(":c2-ssm:ssm-spring:ssm-tx-spring-boot-starter:ssm-tx-config-spring-boot-starter"))
 	api("io.komune.f2:f2-spring-boot-starter-function:${Versions.f2}")
-	kapt("org.springframework.boot:spring-boot-configuration-processor:${FixersVersions.Spring.boot}")
+	kapt("org.springframework.boot:spring-boot-configuration-processor:${Versions.springBoot}")
 
 	testImplementation(project(":c2-ssm:ssm-bdd:ssm-bdd-spring-autoconfigure"))
 }

--- a/c2-ssm/ssm-spring/ssm-tx-spring-boot-starter/ssm-tx-session-perform-action-spring-boot-starter/build.gradle.kts
+++ b/c2-ssm/ssm-spring/ssm-tx-spring-boot-starter/ssm-tx-session-perform-action-spring-boot-starter/build.gradle.kts
@@ -1,5 +1,3 @@
-import io.komune.gradle.dependencies.FixersVersions
-
 plugins {
 	id("io.komune.fixers.gradle.kotlin.jvm")
 	id("io.komune.fixers.gradle.publish")
@@ -14,7 +12,7 @@ dependencies {
 
 	api("io.komune.f2:f2-spring-boot-starter-function:${Versions.f2}")
 
-	kapt("org.springframework.boot:spring-boot-configuration-processor:${FixersVersions.Spring.boot}")
+	kapt("org.springframework.boot:spring-boot-configuration-processor:${Versions.springBoot}")
 
 	testImplementation(project(":c2-ssm:ssm-bdd:ssm-bdd-spring-autoconfigure"))
 }

--- a/c2-ssm/ssm-spring/ssm-tx-spring-boot-starter/ssm-tx-session-start-spring-boot-starter/build.gradle.kts
+++ b/c2-ssm/ssm-spring/ssm-tx-spring-boot-starter/ssm-tx-session-start-spring-boot-starter/build.gradle.kts
@@ -1,5 +1,3 @@
-import io.komune.gradle.dependencies.FixersVersions
-
 plugins {
 	id("io.komune.fixers.gradle.kotlin.jvm")
 	id("io.komune.fixers.gradle.publish")
@@ -11,7 +9,7 @@ dependencies {
 	api(project(":c2-ssm:ssm-tx:ssm-tx-f2"))
 	api(project(":c2-ssm:ssm-spring:ssm-tx-spring-boot-starter:ssm-tx-config-spring-boot-starter"))
 	api("io.komune.f2:f2-spring-boot-starter-function:${Versions.f2}")
-	kapt("org.springframework.boot:spring-boot-configuration-processor:${FixersVersions.Spring.boot}")
+	kapt("org.springframework.boot:spring-boot-configuration-processor:${Versions.springBoot}")
 
 	testImplementation(project(":c2-ssm:ssm-bdd:ssm-bdd-spring-autoconfigure"))
 }

--- a/c2-ssm/ssm-tx/ssm-tx-bdd/build.gradle.kts
+++ b/c2-ssm/ssm-tx/ssm-tx-bdd/build.gradle.kts
@@ -1,5 +1,3 @@
-import io.komune.gradle.dependencies.FixersDependencies
-
 plugins {
 	id("io.komune.fixers.gradle.kotlin.jvm")
 }
@@ -10,5 +8,5 @@ dependencies {
 	implementation(project(":c2-ssm:ssm-sdk:ssm-sdk-bdd"))
 	implementation(project(":c2-ssm:ssm-chaincode:ssm-chaincode-bdd"))
 
-	FixersDependencies.Jvm.Test.cucumber(::api)
+	Dependencies.cucumber(::api)
 }

--- a/make_docker.mk
+++ b/make_docker.mk
@@ -4,7 +4,7 @@ CHAINCODE_APP_NAME	   	 	:= c2-chaincode-api-gateway
 CHAINCODE_APP_IMG	    	:= ${CHAINCODE_APP_NAME}:${VERSION}
 CHAINCODE_APP_PACKAGE	   	:= :c2-chaincode:chaincode-api:chaincode-api-gateway:bootBuildImage
 
-.PHONY: lint build test publish promote
+.PHONY: lint build test stage promote
 
 lint:
 	make lint -C c2-chaincode -e VERSION=$(VERSION)
@@ -14,9 +14,9 @@ build: docker-chaincode-api-gateway-build
 	make build -C c2-chaincode -e VERSION=$(VERSION)
 	make build -C c2-sandbox -e VERSION=$(VERSION)
 
-publish: docker-chaincode-api-gateway-publish
-	make publish -e DOCKER_REPOSITORY=ghcr.io/komune-io/ -C c2-chaincode -e VERSION=$(VERSION)
-	make publish -e DOCKER_REPOSITORY=ghcr.io/komune-io/ -C c2-sandbox -e VERSION=$(VERSION)
+stage: docker-chaincode-api-gateway-stage
+	make push -e DOCKER_REPOSITORY=ghcr.io/komune-io/ -C c2-chaincode -e VERSION=$(VERSION)
+	make push -e DOCKER_REPOSITORY=ghcr.io/komune-io/ -C c2-sandbox -e VERSION=$(VERSION)
 
 promote: docker-chaincode-api-gateway-promote
 	make promote -e DOCKER_REPOSITORY=docker.io/komune/ -C c2-chaincode -e VERSION=$(VERSION)
@@ -26,7 +26,7 @@ promote: docker-chaincode-api-gateway-promote
 docker-chaincode-api-gateway-build:
 	VERSION=$(VERSION) ./gradlew build ${CHAINCODE_APP_PACKAGE} --imageName ${CHAINCODE_APP_IMG} -x test
 
-docker-chaincode-api-gateway-publish:
+docker-chaincode-api-gateway-stage:
 	@docker tag ${CHAINCODE_APP_IMG} ghcr.io/komune-io/${CHAINCODE_APP_IMG}
 	@docker push ghcr.io/komune-io/${CHAINCODE_APP_IMG}
 

--- a/make_libs.mk
+++ b/make_libs.mk
@@ -32,8 +32,8 @@ test:
 test-post:
 	@make dev down
 
-state:
-	VERSION=$(VERSION) ./gradlew state
+stage:
+	VERSION=$(VERSION) ./gradlew stage
 
 promote:
 	VERSION=$(VERSION) ./gradlew promote

--- a/make_libs.mk
+++ b/make_libs.mk
@@ -28,13 +28,15 @@ test-pre:
 
 test:
 	./gradlew test
+
 test-post:
 	@make dev down
 
-publish:
-	VERSION=$(VERSION) PKG_MAVEN_REPO=github ./gradlew publish -Dorg.gradle.parallel=true --info
+state:
+	VERSION=$(VERSION) ./gradlew state
+
 promote:
-	VERSION=$(VERSION) PKG_MAVEN_REPO=sonatype_oss ./gradlew publish
+	VERSION=$(VERSION) ./gradlew promote
 
 .PHONY: version
 version:

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -4,7 +4,7 @@ pluginManagement {
 	repositories {
 		gradlePluginPortal()
 		mavenCentral()
-		maven { url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots") }
+		maven { url = uri("https://central.sonatype.com/repository/maven-snapshots") }
 		mavenLocal()
 	}
 }


### PR DESCRIPTION
Updates Maven repository URLs, renames Makefile targets, and refactors Gradle dependency handling for better clarity and compatibility.

These changes ensure the build process works seamlessly across different environments while improving overall maintainability.