### PR TITLE
chore(build.gradle.kts): conditionally include mavenLocal repository based on environment variable

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,7 +5,9 @@ plugins {
 repositories {
 	mavenCentral()
 	maven { url = uri("https://central.sonatype.com/repository/maven-snapshots") }
-	mavenLocal()
+	if(System.getenv("MAVEN_LOCAL_USE") == "true") {
+		mavenLocal()
+	}
 }
 
 dependencies {

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -38,13 +38,6 @@ object Versions {
 	const val assertj = FixersVersions.Test.assertj
 }
 
-fun RepositoryHandler.defaultRepo() {
-	mavenCentral()
-	maven { url = URI("https://central.sonatype.com/repository/maven-snapshots") }
-	maven { url = URI("https://repo.spring.io/milestone") }
-	mavenLocal()
-}
-
 object Dependencies {
 	fun slf4j(scope: Scope) = FixersDependencies.Jvm.Logging.slf4j(scope)
 
@@ -89,5 +82,14 @@ object Dependencies {
 		"io.projectreactor:reactor-test:${Versions.reactor}",
 		"org.assertj:assertj-core:${Versions.assertj}"
 	)
-
 }
+
+
+fun RepositoryHandler.defaultRepo() {
+    mavenCentral()
+    maven { url = URI("https://central.sonatype.com/repository/maven-snapshots") }
+    if(System.getenv("MAVEN_LOCAL_USE") == "true") {
+        mavenLocal()
+    }
+}
+

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,6 +2,7 @@ pluginManagement {
 	repositories {
 		gradlePluginPortal()
 		mavenCentral()
+		maven { url = uri("https://central.sonatype.com/repository/maven-snapshots") }
 		if(System.getenv("MAVEN_LOCAL_USE") == "true") {
 			mavenLocal()
 		}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,11 +1,10 @@
-
-
 pluginManagement {
 	repositories {
 		gradlePluginPortal()
 		mavenCentral()
-		maven { url = uri("https://central.sonatype.com/repository/maven-snapshots") }
-		mavenLocal()
+		if(System.getenv("MAVEN_LOCAL_USE") == "true") {
+			mavenLocal()
+		}
 	}
 }
 


### PR DESCRIPTION
refactor(Dependencies.kt): move default repository configuration to a single function The changes conditionally include the mavenLocal repository based on the MAVEN_LOCAL_USE environment variable, allowing for more flexible build configurations. The repository setup is refactored into a single function to reduce redundancy and improve maintainability.