### PR TITLE
chore(ci): update GitHub Actions workflow to change on-tag value and add base-dir

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -54,9 +54,10 @@ jobs:
       pages: write
       id-token: write
     with:
-      on-tag: 'stage_promote'
+      on-tag: 'stage promote'
       make-file: 'make_docs.mk'
       with-chromatic: false
+      base-dir: "storybook"
       storybook-dir: storybook
       storybook-static-dir: storybook-static
     secrets:


### PR DESCRIPTION
The on-tag value is modified to 'stage promote' for better clarity and consistency. Additionally, a base-dir is added to specify the directory for Storybook, which helps in organizing the build process and ensuring that the correct files are referenced during the CI workflow.