### PR TITLE
feat: add make clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
 VERSION = $(shell cat VERSION)
 
-.PHONY: lint build test publish promote
+.PHONY: clean lint build test publish promote
 
 ## New
+clean:
+	@make -f infra/make/libs.mk clean
+	@make -f infra/make/docker.mk clean
+
 lint:
 	@make -f infra/make/libs.mk lint
 	@make -f infra/make/docker.mk lint

--- a/infra/make/docker.mk
+++ b/infra/make/docker.mk
@@ -4,7 +4,10 @@ CHAINCODE_APP_NAME	   	 	:= c2-chaincode-api-gateway
 CHAINCODE_APP_IMG	    	:= ${CHAINCODE_APP_NAME}:${VERSION}
 CHAINCODE_APP_PACKAGE	   	:= :c2-chaincode:chaincode-api:chaincode-api-gateway:bootBuildImage
 
-.PHONY: lint build test stage promote
+.PHONY: clean lint build test stage promote
+
+clean:
+	docker rmi ${CHAINCODE_APP_IMG} 2>/dev/null || true
 
 lint:
 	make lint -C c2-chaincode -e VERSION=$(VERSION)

--- a/infra/make/libs.mk
+++ b/infra/make/libs.mk
@@ -1,6 +1,9 @@
 VERSION = $(shell cat VERSION)
 
-.PHONY: lint build test test-pre publish promote
+.PHONY: clean lint build test test-pre publish promote
+
+clean:
+	./gradlew clean
 
 lint:
 	./gradlew detekt


### PR DESCRIPTION
     STDIN
   1 ## Summary
   2 - Add standalone `make clean` target for Gradle build artifacts and Docker images
   3 - `libs.mk` runs `./gradlew clean`, `docker.mk` removes the chaincode API gateway image
   4 - Follows existing delegation pattern: root Makefile → `infra/make/libs.mk` + `infra/make/docker.mk`
   5 
   6 🤖 Generated with [Claude Code](https://claude.com/claude-code)