### PR TITLE
Fix flaky CouchDB and data-f2 tests by making them self-contained

### DIFF
--- a/c2-ssm/ssm-couchdb/ssm-couchdb-bdd/src/test/resources/features/DatabaseEntries.feature
+++ b/c2-ssm/ssm-couchdb/ssm-couchdb-bdd/src/test/resources/features/DatabaseEntries.feature
@@ -1,10 +1,10 @@
 Feature:
-#  Background:
-#    Given a couchdb configuration for local env
-#    And a channel named "sandbox"
-#    And a chaincode ssm names "ssm"
 
   Scenario: As a developer, I want to get all ssm in a database
+    Given An admin
+    And A ssm "db-entries-ssm" with transitions
+      | from | to | role   | action |
+      | 0    | 1  | Tester | Test   |
     Given I have a local database
     When I get all ssm for
       | channelId        | chaincodeId  |

--- a/c2-ssm/ssm-data/ssm-data-f2/src/test/kotlin/ssm/api/features/query/DataSsmSessionListQueryFunctionImplTest.kt
+++ b/c2-ssm/ssm-data/ssm-data-f2/src/test/kotlin/ssm/api/features/query/DataSsmSessionListQueryFunctionImplTest.kt
@@ -2,17 +2,30 @@ package ssm.api.features.query
 
 import f2.dsl.fnc.invoke
 import f2.dsl.fnc.invokeWith
+import java.util.UUID
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import ssm.api.DataSsmQueryFunctionImpl
 import ssm.bdd.config.SsmBddConfig
+import ssm.chaincode.dsl.config.SsmBatchProperties
+import ssm.chaincode.dsl.model.Ssm
+import ssm.chaincode.dsl.model.SsmSession
+import ssm.chaincode.dsl.model.SsmTransition
 import ssm.data.dsl.features.query.DataSsmListQuery
 import ssm.data.dsl.features.query.DataSsmListQueryFunction
 import ssm.data.dsl.features.query.DataSsmSessionListQuery
 import ssm.data.dsl.features.query.DataSsmSessionListQueryFunction
+import ssm.sdk.core.SsmSdkConfig
+import ssm.sdk.core.SsmServiceFactory
+import ssm.sdk.sign.SsmCmdSignerSha256RSASigner
+import ssm.sdk.sign.extention.asAgent
+import ssm.sdk.sign.model.SignerAdmin
+import ssm.sdk.sign.model.SignerUser
 
 internal class DataSsmSessionListQueryFunctionImplTest {
+
+	private val chaincodeUri = SsmBddConfig.Chaincode.chaincodeUri
 
 	private val dataSsmQueryFunction = DataSsmQueryFunctionImpl(
 		SsmBddConfig.Data.config,
@@ -24,12 +37,45 @@ internal class DataSsmSessionListQueryFunctionImplTest {
 
 	@Test
 	fun `test exception`() = runTest {
+		val uuid = UUID.randomUUID().toString().take(8)
+		createSsmWithSession(uuid)
+
 		val ssmListResult = dataSsmListQueryFunction.invoke(
-			DataSsmListQuery(listOf(SsmBddConfig.Chaincode.chaincodeUri))
+			DataSsmListQuery(listOf(chaincodeUri))
 		)
 		val result = DataSsmSessionListQuery(
 			ssmUri = ssmListResult.items.first().uri,
 		).invokeWith(function)
 		Assertions.assertThat(result.items).isNotEmpty()
+	}
+
+	private suspend fun createSsmWithSession(uuid: String) {
+		val admin = SignerAdmin.loadFromFile("ssm-admin", "local/admin/ssm-admin")
+		val factory = SsmServiceFactory.builder(
+			SsmSdkConfig(SsmBddConfig.Chaincode.url),
+			SsmBatchProperties()
+		)
+		val txService = factory.buildTxService(SsmCmdSignerSha256RSASigner(admin))
+
+		val ssmName = "data-test-ssm-$uuid"
+		val ssm = Ssm(
+			name = ssmName,
+			transitions = listOf(
+				SsmTransition(from = 0, to = 1, role = "Tester", action = "Test")
+			)
+		)
+		txService.sendCreate(chaincodeUri, ssm, admin.name)
+
+		val user = SignerUser.generate("data-test-user-$uuid")
+		txService.sendRegisterUser(chaincodeUri, user.asAgent(), admin.name)
+
+		val session = SsmSession(
+			ssm = ssmName,
+			session = "data-test-session-$uuid",
+			roles = mapOf(user.name to "Tester"),
+			public = "",
+			private = null
+		)
+		txService.sendStart(chaincodeUri, session, admin.name)
 	}
 }

--- a/c2-ssm/ssm-data/ssm-data-f2/src/test/kotlin/ssm/api/features/query/DataSsmSessionListQueryFunctionImplTest.kt
+++ b/c2-ssm/ssm-data/ssm-data-f2/src/test/kotlin/ssm/api/features/query/DataSsmSessionListQueryFunctionImplTest.kt
@@ -38,19 +38,23 @@ internal class DataSsmSessionListQueryFunctionImplTest {
 	@Test
 	fun `test exception`() = runTest {
 		val uuid = UUID.randomUUID().toString().take(8)
-		createSsmWithSession(uuid)
+		val createdSsmName = createSsmWithSession(uuid)
 
 		val ssmListResult = dataSsmListQueryFunction.invoke(
 			DataSsmListQuery(listOf(chaincodeUri))
 		)
+		val createdSsmUri = ssmListResult.items
+			.first { it.ssm.name == createdSsmName }
+			.uri
 		val result = DataSsmSessionListQuery(
-			ssmUri = ssmListResult.items.first().uri,
+			ssmUri = createdSsmUri,
 		).invokeWith(function)
 		Assertions.assertThat(result.items).isNotEmpty()
 	}
 
-	private suspend fun createSsmWithSession(uuid: String) {
-		val admin = SignerAdmin.loadFromFile("ssm-admin", "local/admin/ssm-admin")
+	private suspend fun createSsmWithSession(uuid: String): String {
+		val (adminName, adminPath) = SsmBddConfig.Key.admin
+		val admin = SignerAdmin.loadFromFile(adminName, adminPath)
 		val factory = SsmServiceFactory.builder(
 			SsmSdkConfig(SsmBddConfig.Chaincode.url),
 			SsmBatchProperties()
@@ -77,5 +81,6 @@ internal class DataSsmSessionListQueryFunctionImplTest {
 			private = null
 		)
 		txService.sendStart(chaincodeUri, session, admin.name)
+		return ssmName
 	}
 }


### PR DESCRIPTION
## Summary
- Add SSM creation steps to `DatabaseEntries.feature` so the CouchDB BDD test creates its own data before querying, instead of depending on other test modules running first
- Update `DataSsmSessionListQueryFunctionImplTest` to create an SSM, register a user, and start a session before querying, eliminating the dependency on pre-existing blockchain state

## Test plan
- [x] `./gradlew clean test --rerun` passes on first run with a fresh sandbox
- [ ] CI passes without flaky test failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Scenario tests updated to include explicit admin authentication and in-scenario SSM setup for database-entry verification.
  * Added test helpers to create SSMs with active sessions and refined session-query tests to target the intended SSM, improving isolation and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->