### PR TITLE
Fix Dependabot failures by adding explicit ecosystem config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` with only the Gradle ecosystem configured
- This prevents Dependabot from auto-detecting `kotlin-js-store/yarn.lock` as an npm project, which was causing recurring failures (`/kotlin-js-store not found`) since there is no `package.json` in that directory
- The `yarn.lock` is auto-generated by the Kotlin/JS Gradle plugin and should remain committed per Kotlin docs

## Test plan
- [ ] Verify Dependabot runs no longer fail with the `/kotlin-js-store not found` error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled automated weekly dependency update checks to keep build tooling and CI workflow components current.
  * This reduces manual maintenance, helps surface updates promptly, and improves project reliability and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->