### PR TITLE
feat(ci): normalize secrets to FIXERS_PUBLISH_* namespace

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -21,13 +21,13 @@ jobs:
     with:
       make-file: 'infra/make/libs.mk'
     secrets:
-      GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-      GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
-      PKG_GITHUB_USERNAME: ${{ github.actor }}
-      PKG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.JRELEASER_MAVENCENTRAL_USERNAME }}
-      JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.JRELEASER_MAVENCENTRAL_PASSWORD }}
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      FIXERS_PUBLISH_SIGNING_GPG_KEY: ${{ secrets.FIXERS_PUBLISH_SIGNING_GPG_KEY }}
+      FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD: ${{ secrets.FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD }}
+      FIXERS_PUBLISH_GITHUB_USERNAME: ${{ github.actor }}
+      FIXERS_PUBLISH_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME }}
+      FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD }}
+      FIXERS_SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN }}
 
   docker:
     uses: komune-io/fixers-gradle/.github/workflows/make-jvm-workflow.yml@main
@@ -40,12 +40,12 @@ jobs:
       make-file: 'infra/make/docker.mk'
       force-stage: 'true'
     secrets:
-      PKG_GITHUB_USERNAME: ${{ github.actor }}
-      PKG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      FIXERS_PUBLISH_GITHUB_USERNAME: ${{ github.actor }}
+      FIXERS_PUBLISH_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       DOCKER_STAGE_USERNAME: ${{ github.actor }}
       DOCKER_STAGE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-      DOCKER_PROMOTE_USERNAME: ${{ secrets.DOCKER_IO_USERNAME }}
-      DOCKER_PROMOTE_PASSWORD: ${{ secrets.DOCKER_IO_PASSWORD }}
+      DOCKER_PROMOTE_USERNAME: ${{ secrets.FIXERS_DOCKER_HUB_USERNAME }}
+      DOCKER_PROMOTE_PASSWORD: ${{ secrets.FIXERS_DOCKER_HUB_PASSWORD }}
 
   sec:
     needs: libs
@@ -54,4 +54,4 @@ jobs:
       contents: write
       pull-requests: read
     secrets:
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      FIXERS_SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN }}


### PR DESCRIPTION
## Summary
- Rename libs + docker + sec caller pass-throughs
- Hard cutover: no legacy fallback

## Depends on
- komune-io/fixers-gradle#162 (fix/normalize-secrets) must merge first

## Test plan
- [ ] CI green after org secrets are created under FIXERS_* names