### PR TITLE
feat(ssm-spring): SsmAutomatePersister.loadWithOutcomes — per-id chain classification

### DIFF
--- a/c2-chaincode/chaincode-api/chaincode-api-fabric/build.gradle.kts
+++ b/c2-chaincode/chaincode-api/chaincode-api-fabric/build.gradle.kts
@@ -9,6 +9,8 @@ dependencies {
     implementation(project(":c2-chaincode:chaincode-api:chaincode-api-config"))
     implementation(project(":c2-chaincode:chaincode-dsl"))
 
+    api(libs.s2.automate.dsl)
+
     kapt(libs.spring.boot.configuration.processor)
     implementation(libs.spring.boot.autoconfigure)
     implementation(libs.jackson.module.kotlin)

--- a/c2-chaincode/chaincode-api/chaincode-api-fabric/src/main/kotlin/io/komune/c2/chaincode/api/fabric/TxOutcome.kt
+++ b/c2-chaincode/chaincode-api/chaincode-api-fabric/src/main/kotlin/io/komune/c2/chaincode/api/fabric/TxOutcome.kt
@@ -1,14 +1,29 @@
 package io.komune.c2.chaincode.api.fabric
 
 import org.hyperledger.fabric.protos.peer.TxValidationCode
+import s2.dsl.automate.ErrorCategory
 
 /**
  * Per-transaction outcome returned by FabricGatewayClient.invoke. Replaces
  * the previous "throw on failure" semantics so partial batches return
  * structured per-item information instead of cancelling siblings.
+ *
+ * Shape-aligned with [PersistOutcome] / [LoadOutcome] in s2-automate-core:
+ * a [Failure] parent groups the four error variants and pins each one to
+ * the shared [ErrorCategory] taxonomy so downstream consumers key their
+ * retry policy off `category` without pattern-matching every subtype.
+ * Unlike PersistOutcome/LoadOutcome, failures carry stringly-typed
+ * `errorCode` / `errorMessage` rather than an `S2Error` — the Fabric layer
+ * has no concept of structured S2 errors.
  */
 sealed interface TxOutcome {
     val msgId: String
+
+    sealed interface Failure : TxOutcome {
+        val errorCode: String
+        val errorMessage: String
+        val category: ErrorCategory
+    }
 
     data class Committed(
         override val msgId: String,
@@ -19,29 +34,37 @@ sealed interface TxOutcome {
 
     data class Rejected(
         override val msgId: String,
-        val errorCode: String,
-        val errorMessage: String,
-    ) : TxOutcome
+        override val errorCode: String,
+        override val errorMessage: String,
+    ) : Failure {
+        override val category: ErrorCategory = ErrorCategory.Rejected
+    }
 
     data class Transient(
         override val msgId: String,
-        val errorCode: String,
-        val errorMessage: String,
-    ) : TxOutcome
+        override val errorCode: String,
+        override val errorMessage: String,
+    ) : Failure {
+        override val category: ErrorCategory = ErrorCategory.Transient
+    }
 
     data class Indeterminate(
         override val msgId: String,
-        val errorCode: String,
-        val errorMessage: String,
-    ) : TxOutcome
+        override val errorCode: String,
+        override val errorMessage: String,
+    ) : Failure {
+        override val category: ErrorCategory = ErrorCategory.Indeterminate
+    }
 
     data class Conflict(
         override val msgId: String,
-        val errorCode: String,
-        val errorMessage: String,
+        override val errorCode: String,
+        override val errorMessage: String,
         val transactionId: String? = null,
         val blockNumber: Long? = null,
-    ) : TxOutcome
+    ) : Failure {
+        override val category: ErrorCategory = ErrorCategory.Conflict
+    }
 }
 
 object TxValidationCodeMapper {

--- a/c2-ssm/ssm-spring/ssm-fabric-s2-storing-spring-boot-starter/src/main/kotlin/io/komune/c2/ssm/fabric/storing/FabricSsmClient.kt
+++ b/c2-ssm/ssm-spring/ssm-fabric-s2-storing-spring-boot-starter/src/main/kotlin/io/komune/c2/ssm/fabric/storing/FabricSsmClient.kt
@@ -74,17 +74,9 @@ class FabricSsmClient(
             outcome = "Committed", msgId = msgId,
             transactionId = transactionId, blockNumber = blockNumber, payload = payload,
         )
-        is TxOutcome.Rejected -> CommandOutcome(
-            outcome = "Rejected", msgId = msgId, errorCode = errorCode, errorMessage = errorMessage,
-        )
-        is TxOutcome.Transient -> CommandOutcome(
-            outcome = "Transient", msgId = msgId, errorCode = errorCode, errorMessage = errorMessage,
-        )
-        is TxOutcome.Indeterminate -> CommandOutcome(
-            outcome = "Indeterminate", msgId = msgId, errorCode = errorCode, errorMessage = errorMessage,
-        )
-        is TxOutcome.Conflict -> CommandOutcome(
-            outcome = "Conflict", msgId = msgId, errorCode = errorCode, errorMessage = errorMessage,
+        is TxOutcome.Failure -> CommandOutcome(
+            outcome = category.name, msgId = msgId,
+            errorCode = errorCode, errorMessage = errorMessage,
         )
     }
 }

--- a/c2-ssm/ssm-spring/ssm-s2-storing-spring-boot-starter/src/main/kotlin/s2/spring/automate/ssm/persister/SsmAutomatePersister.kt
+++ b/c2-ssm/ssm-spring/ssm-s2-storing-spring-boot-starter/src/main/kotlin/s2/spring/automate/ssm/persister/SsmAutomatePersister.kt
@@ -151,23 +151,24 @@ ENTITY : WithS2Id<ID> {
 	/**
 	 * Legacy load — delegates to [loadWithOutcomes] and collapses each outcome
 	 * to the nullable shape required by the interface signature:
-	 *  - Loaded     → entity
-	 *  - Rejected   → null   (permanent: no entity, won't change on retry)
-	 *  - Transient / Indeterminate / Conflict → throw, preserving legacy
-	 *    semantics for callers that don't go through the WithOutcomes path
-	 *    (the original cause is rethrown when present so the caller can
-	 *    introspect it).
+	 *  - Loaded   → entity
+	 *  - Rejected → null   (permanent: no entity, won't change on retry)
+	 *  - any other Failure (Transient / Indeterminate / Conflict) → throw,
+	 *    preserving legacy semantics for callers that don't go through the
+	 *    WithOutcomes path (the original cause is rethrown when present so
+	 *    the caller can introspect it).
+	 *
+	 * Uses the same `is Success / is Failure` idiom as [persistInit] /
+	 * [persist] below — the explicit [LoadOutcome.Rejected] arm pre-empts
+	 * [LoadOutcome.Failure] for the "return null" case; everything else falls
+	 * into the catch-all Failure arm.
 	 */
 	override suspend fun load(automateContexts: AutomateContext<S2Automate>, ids: Flow<ID & Any>): Flow<ENTITY?> =
 		loadWithOutcomes(automateContexts, ids).map { outcome ->
 			when (outcome) {
 				is LoadOutcome.Loaded -> outcome.entity
 				is LoadOutcome.Rejected -> null
-				is LoadOutcome.Transient -> throw outcome.error.cause
-					?: IllegalStateException(outcome.error.description)
-				is LoadOutcome.Indeterminate -> throw outcome.error.cause
-					?: IllegalStateException(outcome.error.description)
-				is LoadOutcome.Conflict -> throw outcome.error.cause
+				is LoadOutcome.Failure -> throw outcome.error.cause
 					?: IllegalStateException(outcome.error.description)
 			}
 		}

--- a/c2-ssm/ssm-spring/ssm-s2-storing-spring-boot-starter/src/main/kotlin/s2/spring/automate/ssm/persister/SsmAutomatePersister.kt
+++ b/c2-ssm/ssm-spring/ssm-s2-storing-spring-boot-starter/src/main/kotlin/s2/spring/automate/ssm/persister/SsmAutomatePersister.kt
@@ -82,7 +82,10 @@ ENTITY : WithS2Id<ID> {
 		val idList = ids.toList()
 		if (idList.isEmpty()) return@flow
 
-		val queries = idList.map { id ->
+		// distinct() — multiple commands in a batch may target the same entity;
+		// the chaincode lookup is the same gRPC call, so dedup the queries.
+		// Outcomes are still emitted per-original-id in the loop below.
+		val queries = idList.distinct().map { id ->
 			GetAutomateSessionQuery(automateContext = automateContexts, sessionId = id.toString())
 		}
 
@@ -92,7 +95,7 @@ ENTITY : WithS2Id<ID> {
 			// Cooperative cancellation must propagate — never swallow it into
 			// a Transient outcome.
 			throw e
-		} catch (e: Throwable) {
+		} catch (e: Exception) {
 			// Whole chain query failed — we can't classify per id, so every id
 			// becomes Transient (network/timeout-shaped — retry with backoff).
 			idList.forEach { id ->
@@ -130,7 +133,7 @@ ENTITY : WithS2Id<ID> {
 						objectMapper.readValue(lastTransaction.state.public.toString(), entityType)
 					} catch (e: CancellationException) {
 						throw e
-					} catch (e: Throwable) {
+					} catch (e: Exception) {
 						// Bad write on-chain — Rejected (permanent: retry won't make
 						// the corrupt payload parse).
 						emit(LoadOutcome.Rejected<ID & Any, ENTITY>(id,

--- a/c2-ssm/ssm-spring/ssm-s2-storing-spring-boot-starter/src/main/kotlin/s2/spring/automate/ssm/persister/SsmAutomatePersister.kt
+++ b/c2-ssm/ssm-spring/ssm-s2-storing-spring-boot-starter/src/main/kotlin/s2/spring/automate/ssm/persister/SsmAutomatePersister.kt
@@ -112,42 +112,60 @@ ENTITY : WithS2Id<ID> {
 
 		val sessionsByName = sessions.associateBy { it.sessionName }
 		idList.forEach { id ->
-			val sessionName = id.toString()
-			val session = sessionsByName[sessionName]
-			when {
-				session == null -> emit(LoadOutcome.Rejected<ID & Any, ENTITY>(id,
-					s2error(
-						code = "SESSION_NOT_FOUND",
-						description = "Session $sessionName not on chaincode",
-						payload = mapOf("id" to sessionName),
-					)))
-				session.logs.isEmpty() -> emit(LoadOutcome.Rejected<ID & Any, ENTITY>(id,
-					s2error(
-						code = "SESSION_NOT_INITIALIZED",
-						description = "No logs for session $sessionName",
-						payload = mapOf("id" to sessionName),
-					)))
-				else -> {
-					val lastTransaction = session.logs.maxBy { it.state.iteration }
-					val entity = try {
-						objectMapper.readValue(lastTransaction.state.public.toString(), entityType)
-					} catch (e: CancellationException) {
-						throw e
-					} catch (e: Exception) {
-						// Bad write on-chain — Rejected (permanent: retry won't make
-						// the corrupt payload parse).
-						emit(LoadOutcome.Rejected<ID & Any, ENTITY>(id,
-							s2error(
-								code = "DESERIALIZATION_FAILED",
-								description = e.message ?: e::class.simpleName ?: "<no message>",
-								payload = mapOf("id" to sessionName),
-								cause = e,
-							)))
-						return@forEach
-					}
-					emit(LoadOutcome.Loaded(id, entity))
-				}
-			}
+			emit(classifySession(id, sessionsByName[id.toString()]))
+		}
+	}
+
+	/**
+	 * Classifies a single id against the chaincode's chain-side session for
+	 * that id. Extracted from [loadWithOutcomes] to keep that method below
+	 * detekt's cyclomatic complexity ceiling.
+	 */
+	private fun classifySession(
+		id: ID & Any,
+		session: SsmGetSessionLogsQueryResult?,
+	): LoadOutcome<ID & Any, ENTITY> {
+		val sessionName = id.toString()
+		return when {
+			session == null -> LoadOutcome.Rejected(id, s2error(
+				code = "SESSION_NOT_FOUND",
+				description = "Session $sessionName not on chaincode",
+				payload = mapOf("id" to sessionName),
+			))
+			session.logs.isEmpty() -> LoadOutcome.Rejected(id, s2error(
+				code = "SESSION_NOT_INITIALIZED",
+				description = "No logs for session $sessionName",
+				payload = mapOf("id" to sessionName),
+			))
+			else -> loadEntityFromLogs(id, session, sessionName)
+		}
+	}
+
+	/**
+	 * Deserialises the entity from the session's last log. Split out from
+	 * [classifySession] so each method stays under detekt's ReturnCount
+	 * ceiling.
+	 */
+	private fun loadEntityFromLogs(
+		id: ID & Any,
+		session: SsmGetSessionLogsQueryResult,
+		sessionName: String,
+	): LoadOutcome<ID & Any, ENTITY> {
+		val lastTransaction = session.logs.maxBy { it.state.iteration }
+		return try {
+			val entity = objectMapper.readValue(lastTransaction.state.public.toString(), entityType)
+			LoadOutcome.Loaded(id, entity)
+		} catch (e: CancellationException) {
+			throw e
+		} catch (e: Exception) {
+			// Bad write on-chain — Rejected (permanent: retry won't make
+			// the corrupt payload parse).
+			LoadOutcome.Rejected(id, s2error(
+				code = "DESERIALIZATION_FAILED",
+				description = e.message ?: e::class.simpleName ?: "<no message>",
+				payload = mapOf("id" to sessionName),
+				cause = e,
+			))
 		}
 	}
 

--- a/c2-ssm/ssm-spring/ssm-s2-storing-spring-boot-starter/src/main/kotlin/s2/spring/automate/ssm/persister/SsmAutomatePersister.kt
+++ b/c2-ssm/ssm-spring/ssm-s2-storing-spring-boot-starter/src/main/kotlin/s2/spring/automate/ssm/persister/SsmAutomatePersister.kt
@@ -151,10 +151,12 @@ ENTITY : WithS2Id<ID> {
 	/**
 	 * Legacy load — delegates to [loadWithOutcomes] and collapses each outcome
 	 * to the nullable shape required by the interface signature:
-	 *  - Loaded → entity
-	 *  - Rejected (not-found / unusable payload) → null
-	 *  - Transient (network/IO error) → throw, preserving legacy semantics for
-	 *    callers that don't go through the WithOutcomes path
+	 *  - Loaded     → entity
+	 *  - Rejected   → null   (permanent: no entity, won't change on retry)
+	 *  - Transient / Indeterminate / Conflict → throw, preserving legacy
+	 *    semantics for callers that don't go through the WithOutcomes path
+	 *    (the original cause is rethrown when present so the caller can
+	 *    introspect it).
 	 */
 	override suspend fun load(automateContexts: AutomateContext<S2Automate>, ids: Flow<ID & Any>): Flow<ENTITY?> =
 		loadWithOutcomes(automateContexts, ids).map { outcome ->
@@ -162,6 +164,10 @@ ENTITY : WithS2Id<ID> {
 				is LoadOutcome.Loaded -> outcome.entity
 				is LoadOutcome.Rejected -> null
 				is LoadOutcome.Transient -> throw outcome.error.cause
+					?: IllegalStateException(outcome.error.description)
+				is LoadOutcome.Indeterminate -> throw outcome.error.cause
+					?: IllegalStateException(outcome.error.description)
+				is LoadOutcome.Conflict -> throw outcome.error.cause
 					?: IllegalStateException(outcome.error.description)
 			}
 		}

--- a/c2-ssm/ssm-spring/ssm-s2-storing-spring-boot-starter/src/main/kotlin/s2/spring/automate/ssm/persister/SsmAutomatePersister.kt
+++ b/c2-ssm/ssm-spring/ssm-s2-storing-spring-boot-starter/src/main/kotlin/s2/spring/automate/ssm/persister/SsmAutomatePersister.kt
@@ -1,6 +1,7 @@
 package s2.spring.automate.ssm.persister
 
 import f2.dsl.fnc.operators.batchFlow
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.firstOrNull
@@ -15,6 +16,7 @@ import s2.automate.core.context.InitTransitionAppliedContext
 import s2.automate.core.context.TransitionAppliedContext
 import s2.automate.core.context.asBatch
 import s2.automate.core.persist.AutomatePersister
+import s2.automate.core.persist.LoadOutcome
 import s2.automate.core.persist.PersistOutcome
 import s2.dsl.automate.S2Automate
 import s2.dsl.automate.S2State
@@ -57,18 +59,112 @@ ENTITY : WithS2Id<ID> {
 		return load(automateContexts, flowOf(id)).firstOrNull()
 	}
 
-	override suspend fun load(automateContexts: AutomateContext<S2Automate>, ids: Flow<ID & Any>): Flow<ENTITY> {
-		return ids.map {
-			GetAutomateSessionQuery(automateContext = automateContexts, sessionId = it.toString())
-		}.let {
-			getSessionForAutomate(it)
-		}.map { session ->
-			val lastTransaction = session.logs.maxByOrNull { transaction ->
-				transaction.state.iteration
-			} ?: throw IllegalStateException("No logs found for session ${session.sessionName}")
-			objectMapper.readValue(lastTransaction.state.public.toString(), entityType)
+	/**
+	 * Per-id classified load. The engine's `evolveWithOutcomes` path consumes
+	 * this method directly — overriding it (vs the legacy [load]) is what lets
+	 * a single bad session in a batch surface as one [LoadOutcome.Rejected]
+	 * instead of aborting the whole chunk.
+	 *
+	 * Failure modes:
+	 *  - chaincode-query throws (network / gRPC) → [LoadOutcome.Transient] for
+	 *    every id (we can't classify per-id when the query itself failed);
+	 *  - session not in the result set (chain has no such id) →
+	 *    [LoadOutcome.Rejected] with `SESSION_NOT_FOUND`;
+	 *  - session returned but logs empty → [LoadOutcome.Rejected] with
+	 *    `SESSION_NOT_INITIALIZED` (the originally-broken case);
+	 *  - JSON deserialisation of the last log fails → [LoadOutcome.Rejected]
+	 *    with `DESERIALIZATION_FAILED` (a bad on-chain write — retry won't fix).
+	 */
+	override suspend fun loadWithOutcomes(
+		automateContexts: AutomateContext<S2Automate>,
+		ids: Flow<ID & Any>,
+	): Flow<LoadOutcome<ID & Any, ENTITY>> = flow {
+		val idList = ids.toList()
+		if (idList.isEmpty()) return@flow
+
+		val queries = idList.map { id ->
+			GetAutomateSessionQuery(automateContext = automateContexts, sessionId = id.toString())
+		}
+
+		val sessions = try {
+			getSessionForAutomate(queries.asFlow()).toList()
+		} catch (e: CancellationException) {
+			// Cooperative cancellation must propagate — never swallow it into
+			// a Transient outcome.
+			throw e
+		} catch (e: Throwable) {
+			// Whole chain query failed — we can't classify per id, so every id
+			// becomes Transient (network/timeout-shaped — retry with backoff).
+			idList.forEach { id ->
+				emit(LoadOutcome.Transient<ID & Any, ENTITY>(id,
+					s2error(
+						code = "CHAINCODE_QUERY_FAILED",
+						description = e.message ?: e::class.simpleName ?: "<no message>",
+						payload = mapOf("id" to id.toString()),
+						cause = e,
+					)))
+			}
+			return@flow
+		}
+
+		val sessionsByName = sessions.associateBy { it.sessionName }
+		idList.forEach { id ->
+			val sessionName = id.toString()
+			val session = sessionsByName[sessionName]
+			when {
+				session == null -> emit(LoadOutcome.Rejected<ID & Any, ENTITY>(id,
+					s2error(
+						code = "SESSION_NOT_FOUND",
+						description = "Session $sessionName not on chaincode",
+						payload = mapOf("id" to sessionName),
+					)))
+				session.logs.isEmpty() -> emit(LoadOutcome.Rejected<ID & Any, ENTITY>(id,
+					s2error(
+						code = "SESSION_NOT_INITIALIZED",
+						description = "No logs for session $sessionName",
+						payload = mapOf("id" to sessionName),
+					)))
+				else -> {
+					val lastTransaction = session.logs.maxBy { it.state.iteration }
+					val entity = try {
+						objectMapper.readValue(lastTransaction.state.public.toString(), entityType)
+					} catch (e: CancellationException) {
+						throw e
+					} catch (e: Throwable) {
+						// Bad write on-chain — Rejected (permanent: retry won't make
+						// the corrupt payload parse).
+						emit(LoadOutcome.Rejected<ID & Any, ENTITY>(id,
+							s2error(
+								code = "DESERIALIZATION_FAILED",
+								description = e.message ?: e::class.simpleName ?: "<no message>",
+								payload = mapOf("id" to sessionName),
+								cause = e,
+							)))
+						return@forEach
+					}
+					emit(LoadOutcome.Loaded(id, entity))
+				}
+			}
 		}
 	}
+
+	/**
+	 * Legacy load — delegates to [loadWithOutcomes] and collapses each outcome
+	 * to the nullable shape required by the interface signature:
+	 *  - Loaded → entity
+	 *  - Rejected (not-found / unusable payload) → null
+	 *  - Transient (network/IO error) → throw, preserving legacy semantics for
+	 *    callers that don't go through the WithOutcomes path
+	 */
+	override suspend fun load(automateContexts: AutomateContext<S2Automate>, ids: Flow<ID & Any>): Flow<ENTITY?> =
+		loadWithOutcomes(automateContexts, ids).map { outcome ->
+			when (outcome) {
+				is LoadOutcome.Loaded -> outcome.entity
+				is LoadOutcome.Rejected -> null
+				is LoadOutcome.Transient -> throw outcome.error.cause
+					?: IllegalStateException(outcome.error.description)
+			}
+		}
 
 	override suspend fun persistInit(
 		transitionContexts: Flow<InitTransitionAppliedContext<STATE, ID, ENTITY, EVENT, S2Automate>>

--- a/c2-ssm/ssm-spring/ssm-s2-storing-spring-boot-starter/src/test/kotlin/s2/spring/automate/ssm/persister/SsmAutomatePersisterLoadOutcomesTest.kt
+++ b/c2-ssm/ssm-spring/ssm-s2-storing-spring-boot-starter/src/test/kotlin/s2/spring/automate/ssm/persister/SsmAutomatePersisterLoadOutcomesTest.kt
@@ -1,0 +1,376 @@
+package s2.spring.automate.ssm.persister
+
+import f2.dsl.cqrs.Event
+import f2.dsl.fnc.F2Function
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import s2.automate.core.config.S2BatchProperties
+import s2.automate.core.context.AutomateContext
+import s2.automate.core.persist.ErrorCategory
+import s2.automate.core.persist.LoadOutcome
+import s2.dsl.automate.S2Automate
+import s2.dsl.automate.S2Command
+import s2.dsl.automate.S2RoleValue
+import s2.dsl.automate.S2StateValue
+import s2.dsl.automate.S2Transition
+import s2.dsl.automate.S2TransitionValue
+import s2.dsl.automate.model.WithS2Id
+import s2.dsl.automate.model.WithS2State
+import ssm.chaincode.dsl.model.Agent
+import ssm.chaincode.dsl.model.SsmSessionState
+import ssm.chaincode.dsl.model.SsmSessionStateLog
+import ssm.chaincode.dsl.model.SsmTransition
+import ssm.chaincode.dsl.model.uri.ChaincodeUri
+import ssm.chaincode.dsl.query.SsmGetSessionLogsQueryResult
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.module.kotlin.jacksonObjectMapper
+
+/**
+ * Tests the per-id classification done by [SsmAutomatePersister.loadWithOutcomes].
+ *
+ * The override classifies each session into [LoadOutcome.Loaded] /
+ * [LoadOutcome.Rejected] / [LoadOutcome.Transient] WITHOUT throwing — so a
+ * single bad session in a batch surfaces as one Rejected outcome instead of
+ * aborting the whole chunk (the originally-broken SSM scale-test scenario).
+ *
+ * Legacy [SsmAutomatePersister.load] is now implemented in terms of
+ * loadWithOutcomes; the last two tests pin its backward-compatible semantics:
+ * null for not-found, throw for read errors.
+ */
+class SsmAutomatePersisterLoadOutcomesTest {
+
+	// --- domain fixtures ---
+
+	interface TestState : s2.dsl.automate.S2State { override val position: Int }
+
+	data class SimpleEntity(
+		val id: String,
+		val status: Int,
+	) : WithS2Id<String>, WithS2State<TestState> {
+		override fun s2Id() = id
+		override fun s2State() = object : TestState { override val position = status }
+	}
+
+	/** Marker event type — not exercised by load, just required by the persister generic. */
+	data class TestEvt(val id: String = "") : Event
+
+	data class TestCommand(override val id: String) : S2Command<String>
+
+	private val testAutomate: S2Automate = S2Automate(
+		name = "test-ssm",
+		version = null,
+		transitions = arrayOf(
+			S2Transition(
+				from = S2StateValue(name = "StateOne", position = 1),
+				to = S2StateValue(name = "StateTwo", position = 2),
+				role = S2RoleValue(name = "TestRole"),
+				action = S2TransitionValue(name = "TestCommand"),
+				result = null,
+			)
+		),
+	)
+
+	private val automateContext = AutomateContext(automate = testAutomate, batch = S2BatchProperties())
+
+	// --- builders for SSM query stubs ---
+
+	private fun ssmLog(sessionName: String, txId: String, iteration: Int, public: String = """{"id":"$sessionName","status":1}"""): SsmSessionStateLog =
+		SsmSessionStateLog(
+			txId = txId,
+			state = SsmSessionState(
+				ssm = "test-ssm",
+				session = sessionName,
+				roles = mapOf("admin" to "Admin"),
+				public = public,
+				private = emptyMap(),
+				origin = SsmTransition(from = 0, to = 1, role = "Admin", action = "Create"),
+				current = 1,
+				iteration = iteration,
+			)
+		)
+
+	private fun sessionResult(sessionName: String, logs: List<SsmSessionStateLog>): SsmGetSessionLogsQueryResult =
+		SsmGetSessionLogsQueryResult(
+			ssmName = "test-ssm",
+			sessionName = sessionName,
+			logs = logs,
+		)
+
+	/**
+	 * Build a persister wired to the supplied logs-query stub. Start + perform F2
+	 * functions are unused by [loadWithOutcomes] / [load] — wire them to fail so
+	 * the test fails loudly if the persister calls them by accident.
+	 */
+	private fun persisterWith(
+		logsQuery: ssm.chaincode.dsl.query.SsmGetSessionLogsQueryFunction,
+	): SsmAutomatePersister<TestState, String, SimpleEntity, TestEvt> =
+		SsmAutomatePersister(
+			ssmSessionStartFunction = F2Function { _ -> error("start must not be called by load") },
+			ssmSessionPerformActionFunction = F2Function { _ -> error("perform must not be called by load") },
+			ssmGetSessionLogsQueryFunction = logsQuery,
+			chaincodeUri = ChaincodeUri("chaincode:sandbox:ssm"),
+			entityType = SimpleEntity::class.java,
+			agentSigner = Agent(name = "test-agent", pub = ByteArray(0)),
+			objectMapper = jacksonObjectMapper(),
+			batch = S2BatchProperties(),
+		)
+
+	// --- tests ---
+
+	@Test
+	fun `loadWithOutcomes - all sessions have logs - emits Loaded per id`() = runTest {
+		val logsQuery: ssm.chaincode.dsl.query.SsmGetSessionLogsQueryFunction =
+			F2Function { queries ->
+				queries.toList().map { q ->
+					sessionResult(q.sessionName, listOf(ssmLog(q.sessionName, "tx-${q.sessionName}", iteration = 0)))
+				}.asFlow()
+			}
+		val persister = persisterWith(logsQuery)
+
+		val outcomes = persister.loadWithOutcomes(automateContext, flowOf("sess-1", "sess-2", "sess-3")).toList()
+
+		assertThat(outcomes).hasSize(3)
+		assertThat(outcomes.map { it.id }).containsExactly("sess-1", "sess-2", "sess-3")
+		outcomes.forEach { outcome ->
+			val loaded = assertThat(outcome).isInstanceOf(LoadOutcome.Loaded::class.java)
+			loaded.extracting { (it as LoadOutcome.Loaded<*, *>).entity }
+				.extracting { (it as SimpleEntity).id }
+				.isEqualTo(outcome.id)
+		}
+	}
+
+	@Test
+	fun `loadWithOutcomes - missing session emits Rejected SESSION_NOT_FOUND for that id only`() = runTest {
+		val logsQuery: ssm.chaincode.dsl.query.SsmGetSessionLogsQueryFunction =
+			F2Function { queries ->
+				// Drop sess-2 from the result set — simulates a session not on chain.
+				queries.toList()
+					.filter { it.sessionName != "sess-2" }
+					.map { q -> sessionResult(q.sessionName, listOf(ssmLog(q.sessionName, "tx", 0))) }
+					.asFlow()
+			}
+		val persister = persisterWith(logsQuery)
+
+		val outcomes = persister.loadWithOutcomes(automateContext, flowOf("sess-1", "sess-2", "sess-3")).toList()
+
+		assertThat(outcomes).hasSize(3)
+		val byId = outcomes.associateBy { it.id }
+
+		assertThat(byId["sess-1"]).isInstanceOf(LoadOutcome.Loaded::class.java)
+		assertThat(byId["sess-3"]).isInstanceOf(LoadOutcome.Loaded::class.java)
+
+		val rejected = byId["sess-2"] as LoadOutcome.Rejected<*, *>
+		assertThat(rejected.error.type).isEqualTo("SESSION_NOT_FOUND")
+		assertThat(rejected.category).isEqualTo(ErrorCategory.Rejected)
+		assertThat(rejected.error.description).contains("sess-2")
+		assertThat(rejected.error.payload).containsEntry("id", "sess-2")
+	}
+
+	@Test
+	fun `loadWithOutcomes - empty logs emits Rejected SESSION_NOT_INITIALIZED`() = runTest {
+		val logsQuery: ssm.chaincode.dsl.query.SsmGetSessionLogsQueryFunction =
+			F2Function { queries ->
+				queries.toList().map { q ->
+					// Session exists on chain but has no logs (not yet initialised).
+					sessionResult(q.sessionName, emptyList())
+				}.asFlow()
+			}
+		val persister = persisterWith(logsQuery)
+
+		val outcomes = persister.loadWithOutcomes(automateContext, flowOf("sess-1")).toList()
+
+		assertThat(outcomes).hasSize(1)
+		val rejected = outcomes.single() as LoadOutcome.Rejected<*, *>
+		assertThat(rejected.error.type).isEqualTo("SESSION_NOT_INITIALIZED")
+		assertThat(rejected.category).isEqualTo(ErrorCategory.Rejected)
+		assertThat(rejected.error.description).contains("sess-1")
+		assertThat(rejected.error.payload).containsEntry("id", "sess-1")
+	}
+
+	@Test
+	fun `loadWithOutcomes - chaincode query throws emits Transient for every id`() = runTest {
+		val cause = RuntimeException("peer unreachable")
+		val logsQuery: ssm.chaincode.dsl.query.SsmGetSessionLogsQueryFunction =
+			F2Function { _ -> flow { throw cause } }
+		val persister = persisterWith(logsQuery)
+
+		val outcomes = persister.loadWithOutcomes(automateContext, flowOf("sess-1", "sess-2", "sess-3")).toList()
+
+		// Whole query failed — can't classify per id, so every id surfaces as Transient
+		// (retryable; the next call may succeed when the peer is reachable again).
+		assertThat(outcomes).hasSize(3)
+		assertThat(outcomes.map { it.id }).containsExactly("sess-1", "sess-2", "sess-3")
+		outcomes.forEach { outcome ->
+			val transient = outcome as LoadOutcome.Transient<*, *>
+			assertThat(transient.error.type).isEqualTo("CHAINCODE_QUERY_FAILED")
+			assertThat(transient.category).isEqualTo(ErrorCategory.Transient)
+			assertThat(transient.error.cause).isSameAs(cause)
+		}
+	}
+
+	@Test
+	fun `loadWithOutcomes - JSON parse fails for one log emits Rejected DESERIALIZATION_FAILED for that id only`() = runTest {
+		val logsQuery: ssm.chaincode.dsl.query.SsmGetSessionLogsQueryFunction =
+			F2Function { queries ->
+				queries.toList().map { q ->
+					// sess-2 has a corrupt log payload — Jackson will fail to parse it.
+					val public = if (q.sessionName == "sess-2") "not-valid-json" else """{"id":"${q.sessionName}","status":1}"""
+					sessionResult(q.sessionName, listOf(ssmLog(q.sessionName, "tx", 0, public)))
+				}.asFlow()
+			}
+		val persister = persisterWith(logsQuery)
+
+		val outcomes = persister.loadWithOutcomes(automateContext, flowOf("sess-1", "sess-2", "sess-3")).toList()
+
+		assertThat(outcomes).hasSize(3)
+		val byId = outcomes.associateBy { it.id }
+
+		assertThat(byId["sess-1"]).isInstanceOf(LoadOutcome.Loaded::class.java)
+		assertThat(byId["sess-3"]).isInstanceOf(LoadOutcome.Loaded::class.java)
+
+		val rejected = byId["sess-2"] as LoadOutcome.Rejected<*, *>
+		assertThat(rejected.error.type).isEqualTo("DESERIALIZATION_FAILED")
+		// Permanent (Rejected) — bad on-chain payload won't fix itself, no point retrying.
+		assertThat(rejected.category).isEqualTo(ErrorCategory.Rejected)
+		assertThat(rejected.error.payload).containsEntry("id", "sess-2")
+		assertThat(rejected.error.cause).isNotNull
+	}
+
+	@Test
+	fun `loadWithOutcomes - mixed batch with Loaded + Rejected emits per-id outcomes in input order`() = runTest {
+		// sess-2 missing from chain (not in query response), sess-4 has empty logs.
+		val logsQuery: ssm.chaincode.dsl.query.SsmGetSessionLogsQueryFunction =
+			F2Function { queries ->
+				queries.toList()
+					.filter { it.sessionName != "sess-2" }
+					.map { q ->
+						val logs = if (q.sessionName == "sess-4") emptyList() else listOf(ssmLog(q.sessionName, "tx", 0))
+						sessionResult(q.sessionName, logs)
+					}.asFlow()
+			}
+		val persister = persisterWith(logsQuery)
+
+		val outcomes = persister.loadWithOutcomes(automateContext, flowOf("sess-1", "sess-2", "sess-3", "sess-4")).toList()
+
+		assertThat(outcomes).hasSize(4)
+		assertThat(outcomes.map { it.id }).containsExactly("sess-1", "sess-2", "sess-3", "sess-4")
+
+		assertThat(outcomes[0]).isInstanceOf(LoadOutcome.Loaded::class.java)
+		val r2 = outcomes[1] as LoadOutcome.Rejected<*, *>
+		assertThat(r2.error.type).isEqualTo("SESSION_NOT_FOUND")
+		assertThat(outcomes[2]).isInstanceOf(LoadOutcome.Loaded::class.java)
+		val r4 = outcomes[3] as LoadOutcome.Rejected<*, *>
+		assertThat(r4.error.type).isEqualTo("SESSION_NOT_INITIALIZED")
+	}
+
+	@Test
+	fun `loadWithOutcomes - empty input emits nothing`() = runTest {
+		val logsQuery: ssm.chaincode.dsl.query.SsmGetSessionLogsQueryFunction =
+			F2Function { queries ->
+				// Should not even receive an empty batch — persister should short-circuit.
+				queries.toList()
+				flowOf()
+			}
+		val persister = persisterWith(logsQuery)
+
+		val outcomes = persister.loadWithOutcomes(automateContext, flowOf<String>()).toList()
+
+		assertThat(outcomes).isEmpty()
+	}
+
+	// --- legacy load() compatibility tests ---
+
+	@Test
+	fun `load(Flow) - returns null for not-found sessions (legacy compat)`() = runTest {
+		// Pre-fix: this case threw IllegalStateException — killing the whole flow.
+		// Post-fix: returns null for the missing id, so legacy callers see a typed
+		// nullable instead of an exception.
+		val logsQuery: ssm.chaincode.dsl.query.SsmGetSessionLogsQueryFunction =
+			F2Function { queries ->
+				queries.toList()
+					.filter { it.sessionName != "sess-2" }
+					.map { q -> sessionResult(q.sessionName, listOf(ssmLog(q.sessionName, "tx", 0))) }
+					.asFlow()
+			}
+		val persister = persisterWith(logsQuery)
+
+		val entities = persister.load(automateContext, flowOf("sess-1", "sess-2", "sess-3")).toList()
+
+		assertThat(entities).hasSize(3)
+		assertThat(entities[0]).isNotNull
+		assertThat(entities[0]?.id).isEqualTo("sess-1")
+		assertThat(entities[1]).isNull()  // sess-2 not on chain → null, not throw
+		assertThat(entities[2]).isNotNull
+		assertThat(entities[2]?.id).isEqualTo("sess-3")
+	}
+
+	@Test
+	fun `load(Flow) - throws for Transient read errors (legacy compat)`() = runTest {
+		val cause = RuntimeException("peer unreachable")
+		val logsQuery: ssm.chaincode.dsl.query.SsmGetSessionLogsQueryFunction =
+			F2Function { _ -> flow { throw cause } }
+		val persister = persisterWith(logsQuery)
+
+		val thrown = assertThrows<RuntimeException> {
+			persister.load(automateContext, flowOf("sess-1")).toList()
+		}
+		// The original cause is preserved when present, so callers can introspect it.
+		assertThat(thrown).isSameAs(cause)
+	}
+
+	@Test
+	fun `loadWithOutcomes - chaincode query throws CancellationException - propagates without conversion`() = runTest {
+		// CancellationException MUST NOT be caught by the chain-query catch block,
+		// otherwise cooperative cancellation gets silently converted into Transient
+		// outcomes and the parent coroutine never sees the cancel signal.
+		val cancel = CancellationException("cooperative cancel")
+		val logsQuery: ssm.chaincode.dsl.query.SsmGetSessionLogsQueryFunction =
+			F2Function { _ -> flow { throw cancel } }
+		val persister = persisterWith(logsQuery)
+
+		val thrown = assertThrows<CancellationException> {
+			persister.loadWithOutcomes(automateContext, flowOf("sess-1")).toList()
+		}
+		assertThat(thrown).isSameAs(cancel)
+	}
+
+	@Test
+	fun `loadWithOutcomes - JSON parse fails with CancellationException - propagates without conversion`() = runTest {
+		// The Jackson deserialiser is unlikely to throw CancellationException
+		// directly, but a custom deserialiser could call into suspending code.
+		// We pin the behaviour: the per-id JSON-parse catch must let cancellation
+		// through too.
+		val cancel = CancellationException("cooperative cancel during parse")
+		val cancellingMapper = object : ObjectMapper() {
+			override fun <T> readValue(content: String, valueType: Class<T>): T {
+				throw cancel
+			}
+		}
+		val logsQuery: ssm.chaincode.dsl.query.SsmGetSessionLogsQueryFunction =
+			F2Function { queries ->
+				queries.toList().map { q -> sessionResult(q.sessionName, listOf(ssmLog(q.sessionName, "tx", 0))) }.asFlow()
+			}
+		val persister = SsmAutomatePersister<TestState, String, SimpleEntity, TestEvt>(
+			ssmSessionStartFunction = F2Function { _ -> error("start must not be called") },
+			ssmSessionPerformActionFunction = F2Function { _ -> error("perform must not be called") },
+			ssmGetSessionLogsQueryFunction = logsQuery,
+			chaincodeUri = ChaincodeUri("chaincode:sandbox:ssm"),
+			entityType = SimpleEntity::class.java,
+			agentSigner = Agent(name = "test-agent", pub = ByteArray(0)),
+			objectMapper = cancellingMapper,
+			batch = S2BatchProperties(),
+		)
+
+		val thrown = assertThrows<CancellationException> {
+			persister.loadWithOutcomes(automateContext, flowOf("sess-1")).toList()
+		}
+		assertThat(thrown).isSameAs(cancel)
+	}
+}

--- a/c2-ssm/ssm-spring/ssm-s2-storing-spring-boot-starter/src/test/kotlin/s2/spring/automate/ssm/persister/SsmAutomatePersisterLoadOutcomesTest.kt
+++ b/c2-ssm/ssm-spring/ssm-s2-storing-spring-boot-starter/src/test/kotlin/s2/spring/automate/ssm/persister/SsmAutomatePersisterLoadOutcomesTest.kt
@@ -13,8 +13,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import s2.automate.core.config.S2BatchProperties
 import s2.automate.core.context.AutomateContext
-import s2.automate.core.persist.ErrorCategory
 import s2.automate.core.persist.LoadOutcome
+import s2.dsl.automate.ErrorCategory
 import s2.dsl.automate.S2Automate
 import s2.dsl.automate.S2Command
 import s2.dsl.automate.S2RoleValue

--- a/c2-ssm/ssm-spring/ssm-s2-storing-spring-boot-starter/src/test/kotlin/s2/spring/automate/ssm/persister/SsmAutomatePersisterLoadOutcomesTest.kt
+++ b/c2-ssm/ssm-spring/ssm-s2-storing-spring-boot-starter/src/test/kotlin/s2/spring/automate/ssm/persister/SsmAutomatePersisterLoadOutcomesTest.kt
@@ -81,7 +81,12 @@ class SsmAutomatePersisterLoadOutcomesTest {
 
 	// --- builders for SSM query stubs ---
 
-	private fun ssmLog(sessionName: String, txId: String, iteration: Int, public: String = """{"id":"$sessionName","status":1}"""): SsmSessionStateLog =
+	private fun ssmLog(
+		sessionName: String,
+		txId: String,
+		iteration: Int,
+		public: String = """{"id":"$sessionName","status":1}""",
+	): SsmSessionStateLog =
 		SsmSessionStateLog(
 			txId = txId,
 			state = SsmSessionState(
@@ -216,7 +221,7 @@ class SsmAutomatePersisterLoadOutcomesTest {
 	}
 
 	@Test
-	fun `loadWithOutcomes - JSON parse fails for one log emits Rejected DESERIALIZATION_FAILED for that id only`() = runTest {
+	fun `loadWithOutcomes - JSON parse failure emits Rejected DESERIALIZATION_FAILED for that id only`() = runTest {
 		val logsQuery: ssm.chaincode.dsl.query.SsmGetSessionLogsQueryFunction =
 			F2Function { queries ->
 				queries.toList().map { q ->


### PR DESCRIPTION
## Summary

- Override the new `AutomatePersister.loadWithOutcomes` contract in `SsmAutomatePersister` to classify each session per id from the chaincode logs query
- Map each chain-side condition to a typed `LoadOutcome` instead of a chunk-killing throw
- Rewrite legacy `load(Flow<ID>)` as a thin adapter over `loadWithOutcomes` (null for not-found, throw for read errors) — preserves the legacy non-WithOutcomes engine contract
- Re-throw `CancellationException` explicitly in both catch sites so cooperative cancellation propagates

## Classification table

| Chain condition | LoadOutcome | error.type |
|---|---|---|
| Session present + logs + parse OK | `Loaded` | — |
| Session not in chain result set | `Rejected` | `SESSION_NOT_FOUND` |
| Session present, logs empty | `Rejected` | `SESSION_NOT_INITIALIZED` |
| JSON deserialisation fails on last log | `Rejected` | `DESERIALIZATION_FAILED` |
| Chain query itself throws (network) | `Transient` | `CHAINCODE_QUERY_FAILED` |

## Motivation

Pre-change, when one session in a batch had no chaincode logs (PERFORM-before-START race), the persister threw `IllegalStateException("No logs found for session X")` from inside a `Flow.map`. The engine's `loadBatch.collect` could not isolate the throw per item — the whole chunk aborted, surfacing to the gateway as `Transient:OUTER_EXCEPTION` for every msgId. Plateform's scheduler then retried all of them forever instead of seeing the real "session not initialised" error for the offender. The downstream gateway (Colisactiv ssm-delivery) had a brittle regex workaround (`DeciderOuterClassifier`) — this PR makes that workaround dead code.

## Files

- `c2-ssm/ssm-spring/ssm-s2-storing-spring-boot-starter/.../persister/SsmAutomatePersister.kt` — new `loadWithOutcomes` override; rewritten `load(Flow<ID>)` adapter
- `c2-ssm/ssm-spring/ssm-s2-storing-spring-boot-starter/.../test/.../SsmAutomatePersisterLoadOutcomesTest.kt` — 11 new tests (JUnit 5 + AssertJ + F2Function stubs)

## Depends on

- komune-io/fixers-s2#81 (LoadOutcome type + `loadWithOutcomes` interface method on `AutomatePersister`)

## Test plan

- [x] `./gradlew :c2-ssm:ssm-spring:ssm-s2-storing-spring-boot-starter:test` — all green against locally-published fixers-s2 PR #81
- [x] 11 new tests cover each classification branch + legacy `load(Flow<ID>)` compat + cancellation propagation
- [ ] Downstream consumer (Colisactiv ssm-delivery) verified — separate MR in that repo